### PR TITLE
use slash instead of backslash in load()

### DIFF
--- a/src/test/java/io/vertx/test/lang/js/JSRunner.java
+++ b/src/test/java/io/vertx/test/lang/js/JSRunner.java
@@ -5,6 +5,8 @@ import io.vertx.lang.js.ClasspathFileResolver;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
+
+import java.io.File;
 import java.net.URL;
 
 /**
@@ -47,6 +49,9 @@ public class JSRunner {
         throw new IllegalStateException("Cannot find " + scriptName + " on classpath");
       }
       file = url.getFile();
+    }
+    if (File.separatorChar != '/') {
+      file = file.replace(File.separatorChar, '/');
     }
     engine.eval("load('" + file + "');");
 


### PR DESCRIPTION
use slash instead of backslash (this broke js includes in Windows
since the parser interprets this as escaped hex chars)

for example a require file contains the following eval code
    load('.vertx\debug-js\vertx-js\util\jvm-npm.js');
which gives an error Invalid hex digit in <eval>

this fix should not affect Linux at all, since there File.separatorChar is / anyway
