### PR TITLE
Improve Nashorn method dispatching by using explicit method selection

### DIFF
--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -538,12 +538,7 @@ Here's an example of using an isolation group to isolate a verticle deployment.
 
 [source,js]
 ----
-var options = {
-  "isolationGroup" : "mygroup"
-};
-options.extraClasspath = Java.type("java.util.Arrays").asList("lib/jars/some-library.jar");
-vertx.deployVerticle("com.mycompany.MyIsolatedVerticle", options);
-
+todo
 ----
 
 Isolation groups are identified by a name, and the name can be used between different deployments if you want them

--- a/src/main/resources/vertx-js/template/js.templ
+++ b/src/main/resources/vertx-js/template/js.templ
@@ -51,7 +51,16 @@
 @comment{"===================================="}
 
 @declare{'genMethodCall'}
-@if{static}J@{ifaceSimpleName}@else{}j_@{ifaceName}@end{}.@{method.name}(
+@if{static}J@{ifaceSimpleName}@else{}j_@{ifaceName}@end{}["@{method.name}(
+	@foreach{param: method.params}
+		@if{param.type instanceof io.vertx.codegen.TypeInfo$Parameterized}
+			@{param.type.raw.name}
+		@else{param.type instanceof io.vertx.codegen.TypeInfo$Variable}
+			java.lang.Object
+		@else{}
+			@{param.type.name}
+		@end{}
+	@end{","})"](
 	@code{pcnt=0;}
 	@foreach{param: method.params}
 		@code{argName='__args[' + (pcnt++) + ']';}


### PR DESCRIPTION
@purplefox this is a PR that change the generated code to select the exact Java method of the delegate to dispatch to. There are two interests:

- avoid ambiguity at runtime, because the @VertxGen implementation can provide methods creating an ambiguity for Nashorn (e.g Vertx#executeBlocking)
- ability to cache the methods to avoid to pay the dispatch cost as we actually implement ourself the dispatch with the generated if/else (not done but trivial to do).

WDYT ?