### PR TITLE
Provides a dedicated script context for each Javascript Verticle.

### DIFF
--- a/src/main/resources/vertx-js/util/verticle_globals.js
+++ b/src/main/resources/vertx-js/util/verticle_globals.js
@@ -1,0 +1,12 @@
+/**
+ * Sets up the context for a Verticle. All globally accessible VertX APIs are to be defined here.
+ */
+var Vertx = require('vertx-js/vertx');
+var vertx = new Vertx(__jvertx);  // Must be provided by the context bindings
+var console = require('vertx-js/util/console');
+var setTimeout = function(callback,delay) { return vertx.setTimer(delay, callback); };
+var clearTimeout = function(id) { vertx.cancelTimer(id); };
+var setInterval = function(callback, delay) { return vertx.setPeriodic(delay, callback); };
+var clearInterval = clearTimeout;
+var parent = this;
+var global = this;

--- a/src/main/resources/vertx-js/util/verticle_nodejs_process.js
+++ b/src/main/resources/vertx-js/util/verticle_nodejs_process.js
@@ -1,0 +1,3 @@
+var process = {};
+
+process.env=java.lang.System.getenv();

--- a/src/test/java/io/vertx/test/lang/js/DeployTest.java
+++ b/src/test/java/io/vertx/test/lang/js/DeployTest.java
@@ -51,4 +51,8 @@ public class DeployTest extends JSTestBase {
     runTest();
   }
 
+  @Test
+  public void testVerticleGlobalIsolation() throws Exception {
+    runTest();
+  }
 }

--- a/src/test/java/io/vertx/test/lang/js/RequireTest.java
+++ b/src/test/java/io/vertx/test/lang/js/RequireTest.java
@@ -72,4 +72,9 @@ public class RequireTest extends JSTestBase {
     runTest();
   }
 
+  @Test
+  public void testMultipleConcurrentRequires() throws Exception {
+    runTest();
+  }
+
 }

--- a/src/test/resources/test_multiple_concurrent_requires_required.js
+++ b/src/test/resources/test_multiple_concurrent_requires_required.js
@@ -1,0 +1,9 @@
+function ConcurrencyTest() {}
+
+// Just a test property, this will sometimes be undefined if the require failed
+ConcurrencyTest.testProperty = function() {
+  return true;
+};
+
+module.exports = ConcurrencyTest;
+

--- a/src/test/resources/test_multiple_concurrent_requires_verticle.js
+++ b/src/test/resources/test_multiple_concurrent_requires_verticle.js
@@ -1,0 +1,9 @@
+var RequiredResource = require("test_multiple_concurrent_requires_required.js");
+
+if (RequiredResource == null) {
+  vertx.eventBus().send("test_multiple_concurrent_requires", "failed: Resource is null");
+} else if (RequiredResource.testProperty == null) {
+  vertx.eventBus().send("test_multiple_concurrent_requires", "failed: Property is null");
+} else {
+  vertx.eventBus().send("test_multiple_concurrent_requires", "ok");
+}

--- a/src/test/resources/test_verticle_isolation.js
+++ b/src/test/resources/test_verticle_isolation.js
@@ -1,0 +1,35 @@
+/**
+ * Tests the Javascript global variable isolation within a verticle. Sets up a scoped counter and an accidentally
+ * globally scoped variable (x). Increments both of them after a delay and validates that both are what are expected
+ * at each interval.
+ *
+ * This test will fail when multiple verticle instances on multiple threads are updating the same global space.
+ *
+ * This is only a simple example of the multi threaded isolation issue: jvm npm has a very serious race condition
+ * where multiple verticle instances make use of require which causes the JVM NPM internal caching to fail and provide
+ * undefined dependencies to multiple verticles. This is fixed by the per verticle isolation.
+ */
+var counter = 0,// Internal, private counter limited to the Verticle scope by require
+  period = Math.floor((Math.random() * 200) + 1) + 50;// Just to stagger the Verticles updating between 50ms and 250ms intervals.
+  x = 0; // Example of an accidental leak, but could be in any included NPM module (without isolation could be any include
+         // by any Verticle deployed in the same JVM). Will be global for all Verticle instances if Isolation is not correct.
+
+var reportIterations = 10;
+
+vertx.setPeriodic( period, function() {
+  // We increment both in the same way
+  counter++;
+  x++;
+
+  if (x != counter) {
+    // They are different, there is no point continuing as this is a failure of the Verticle isolation.
+    vertx.eventBus().send("test_verticle_isolation", "fail");
+
+  } else if ( counter % 10 == 0) {
+    // Items are equal, which is what we want
+    if (counter >= reportIterations) {
+      vertx.eventBus().send("test_verticle_isolation", "ok");
+    }
+  }
+});
+


### PR DESCRIPTION
As JavaScript as a language is inherently single threaded (and implementations such as NodeJS and all Browser environments are as well), the majority of Javascript Libraries are not designed to be accessed in a multi threaded environment. Having a single global context for all Javascript Verticles (and Verticle instances) and their dependencies (of which VertX states compatibility with NPM) is extremely likely to introduce race conditions on either access to global variables or even instance variables within a script that is not designed to provide atomic updates (e.g. for internal state).

The JVM NPM library itself (which is used by VertX for NPM/CommonJS support) contains a serious race condition for its internal require cache, where multiple concurrent access (e.g. vert run service.js -instances 10) causes the return value from the 'require' call to be undefined for an indeterminate number of the instances. This patch fixes that issue among potentially many others.

The main changes are to JSVerticleFactory which is really minor refactoring and the introduction of per Verticle ScriptContexts so that there is a 'global' Script Context per standard Verticle Thread (which is the expected behaviour and consistent with the standard VertX approach).

Also added tests related to two manifestations of the issue which fail before this change and pass afterward. All existing tests execute without issue.

Again, I believe that this behaviour is what pretty much all Javascript developers would be expecting. If they do need access to shared data, that is what the VertX API and Clustering is there to provide. The javascript environment of each thread should be isolated from the other threads.