### PR TITLE
Test cases only for https://github.com/vert-x3/vertx-lang-js/pull/21

### DIFF
--- a/src/test/java/io/vertx/test/lang/js/DeployTest.java
+++ b/src/test/java/io/vertx/test/lang/js/DeployTest.java
@@ -51,4 +51,8 @@ public class DeployTest extends JSTestBase {
     runTest();
   }
 
+  @Test
+  public void testVerticleGlobalIsolation() throws Exception {
+    runTest();
+  }
 }

--- a/src/test/java/io/vertx/test/lang/js/RequireTest.java
+++ b/src/test/java/io/vertx/test/lang/js/RequireTest.java
@@ -72,4 +72,9 @@ public class RequireTest extends JSTestBase {
     runTest();
   }
 
+  @Test
+  public void testMultipleConcurrentRequires() throws Exception {
+    runTest();
+  }
+
 }

--- a/src/test/resources/test_multiple_concurrent_requires_required.js
+++ b/src/test/resources/test_multiple_concurrent_requires_required.js
@@ -1,0 +1,9 @@
+function ConcurrencyTest() {}
+
+// Just a test property, this will sometimes be undefined if the require failed
+ConcurrencyTest.testProperty = function() {
+  return true;
+};
+
+module.exports = ConcurrencyTest;
+

--- a/src/test/resources/test_multiple_concurrent_requires_verticle.js
+++ b/src/test/resources/test_multiple_concurrent_requires_verticle.js
@@ -1,0 +1,9 @@
+var RequiredResource = require("test_multiple_concurrent_requires_required.js");
+
+if (RequiredResource == null) {
+  vertx.eventBus().send("test_multiple_concurrent_requires", "failed: Resource is null");
+} else if (RequiredResource.testProperty == null) {
+  vertx.eventBus().send("test_multiple_concurrent_requires", "failed: Property is null");
+} else {
+  vertx.eventBus().send("test_multiple_concurrent_requires", "ok");
+}

--- a/src/test/resources/test_verticle_isolation.js
+++ b/src/test/resources/test_verticle_isolation.js
@@ -1,0 +1,35 @@
+/**
+ * Tests the Javascript global variable isolation within a verticle. Sets up a scoped counter and an accidentally
+ * globally scoped variable (x). Increments both of them after a delay and validates that both are what are expected
+ * at each interval.
+ *
+ * This test will fail when multiple verticle instances on multiple threads are updating the same global space.
+ *
+ * This is only a simple example of the multi threaded isolation issue: jvm npm has a very serious race condition
+ * where multiple verticle instances make use of require which causes the JVM NPM internal caching to fail and provide
+ * undefined dependencies to multiple verticles. This is fixed by the per verticle isolation.
+ */
+var counter = 0,// Internal, private counter limited to the Verticle scope by require
+  period = Math.floor((Math.random() * 200) + 1) + 50;// Just to stagger the Verticles updating between 50ms and 250ms intervals.
+  x = 0; // Example of an accidental leak, but could be in any included NPM module (without isolation could be any include
+         // by any Verticle deployed in the same JVM). Will be global for all Verticle instances if Isolation is not correct.
+
+var reportIterations = 10;
+
+vertx.setPeriodic( period, function() {
+  // We increment both in the same way
+  counter++;
+  x++;
+
+  if (x != counter) {
+    // They are different, there is no point continuing as this is a failure of the Verticle isolation.
+    vertx.eventBus().send("test_verticle_isolation", "fail");
+
+  } else if ( counter % 10 == 0) {
+    // Items are equal, which is what we want
+    if (counter >= reportIterations) {
+      vertx.eventBus().send("test_verticle_isolation", "ok");
+    }
+  }
+});
+


### PR DESCRIPTION
As requested by Tim: Test reproducers only for PR https://github.com/vert-x3/vertx-lang-js/pull/21

Related to issue: https://github.com/vert-x3/vertx-lang-js/issues/20

Tests are identical to the ones in the other PR. Apologies if a PR isn't appropriate for the reproducers, but this is the first one I've done and I couldn't find another way that was appropriate. 

