### PR TITLE
Detect Java.synchronized

### DIFF
--- a/src/main/asciidoc/js/override/verticles.adoc
+++ b/src/main/asciidoc/js/override/verticles.adoc
@@ -1,7 +1,10 @@
 === Writing Verticles
 
 JavaScript verticles are implemented either as http://wiki.commonjs.org/wiki/Modules/1.1[CommonJS modules] or
-https://www.npmjs.com/[NPM] modules
+https://www.npmjs.com/[NPM] modules.
+
+IMPORTANT: JavaScript support requires Java 1.8.0_45+. You can check your Java version with `java -version`. Please
+update if needed.
 
 Here's an example JavaScript verticle written as a CommonJS module.
 
@@ -75,7 +78,7 @@ Here's an example:
 [source, javascript]
 ----
 exports.vertxStartAsync = function(startFuture) {
- vertx.deployVerticle("verticle.js", function(res) {
+ vertx.deployVerticle("verticle.js", function(res, err) {
    if (err) {
      startFuture.fail();
    } else {

--- a/src/main/asciidoc/js/parsetools.adoc
+++ b/src/main/asciidoc/js/parsetools.adoc
@@ -1,3 +1,55 @@
-== Parse tools
+== Record Parser
 
-TODO
+The record parser allows you to easily parse protocols which are delimited by a sequence of bytes, or fixed
+size records.
+
+It transforms an sequence of input buffer to a sequence of buffer structured as configured (either
+fixed size or separated records).
+
+For example, if you have a simple ASCII text protocol delimited by '\n' and the input is the following:
+
+[source]
+----
+buffer1:HELLO\nHOW ARE Y
+buffer2:OU?\nI AM
+buffer3: DOING OK
+buffer4:\n
+----
+
+The record parser would produce
+[source]
+----
+buffer1:HELLO
+buffer2:HOW ARE YOU?
+buffer3:I AM DOING OK
+----
+
+Let's see the associated code:
+
+[source, js]
+----
+var RecordParser = require("vertx-js/record_parser");
+var Buffer = require("vertx-js/buffer");
+var parser = RecordParser.newDelimited("\n", function (h) {
+  console.log(h.toString());
+});
+
+parser.handle(Buffer.buffer("HELLO\nHOW ARE Y"));
+parser.handle(Buffer.buffer("OU?\nI AM"));
+parser.handle(Buffer.buffer("DOING OK"));
+parser.handle(Buffer.buffer("\n"));
+
+----
+
+You can also produce fixed sized chunks as follows:
+
+[source, js]
+----
+var RecordParser = require("vertx-js/record_parser");
+RecordParser.newFixed(4, function (h) {
+  console.log(h.toString());
+});
+
+----
+
+For more details, check out the `link:jsdoc/record_parser-RecordParser.html[RecordParser]` class.

--- a/src/main/docoverride/docoverride/verticles/package-info.java
+++ b/src/main/docoverride/docoverride/verticles/package-info.java
@@ -18,7 +18,10 @@
  * === Writing Verticles
  *
  * JavaScript verticles are implemented either as http://wiki.commonjs.org/wiki/Modules/1.1[CommonJS modules] or
- * https://www.npmjs.com/[NPM] modules
+ * https://www.npmjs.com/[NPM] modules.
+ *
+ * IMPORTANT: JavaScript support requires Java 1.8.0_45+. You can check your Java version with `java -version`. Please
+ * update if needed.
  *
  * Here's an example JavaScript verticle written as a CommonJS module.
  *

--- a/src/main/resources/vertx-js/util/jvm-npm.js
+++ b/src/main/resources/vertx-js/util/jvm-npm.js
@@ -24,6 +24,12 @@
 
 module = (typeof module == 'undefined') ? {} : module;
 
+// Java.synchronized is used in jvm-npm.js to synchronize concurrent access to require but this is only available in
+// JDK 8u45 or later. So, if not there, just throw an error.
+if (typeof Java.synchronized == 'undefined') {
+  throw "Please update your java virtual machine, Java 1.8.0_45+ is required by the vert.x JavaScript support";
+}
+
 (function () {
   var System = java.lang.System;
   var Scanner = java.util.Scanner;


### PR DESCRIPTION
Fix #20 

While initializing jvm-npm, check whether java.synchronized is defined. If not, throw an exception inviting the user to update his Java environment.

It also updates the documentation to mention the requirement.