### PR TITLE
Fix sub-module resolution on windows

### DIFF
--- a/src/main/resources/vertx-js/util/jvm-npm.js
+++ b/src/main/resources/vertx-js/util/jvm-npm.js
@@ -222,7 +222,8 @@ if (typeof Java.synchronized == 'undefined') {
     if (!modParent || !modParent.id) {
       return Require.root;
     }
-    var pathParts = modParent.id.split('/');
+    // The id is the path, so, the split must be system dependent.
+    var pathParts = modParent.id.split(File.separator);
     pathParts.pop();
     return pathParts.join('/');
   }


### PR DESCRIPTION
Fix #40.

When computing the root from the parent module, it is system dependent, as the 'id' is the path. So the split operation must use File.separator.