### PR TITLE
Generics improvements

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -166,6 +166,11 @@ Set the idle timeout, in seconds. zero means don't timeout.
 +++
 Set the key/cert options in jks format, aka Java keystore.
 +++
+|[[localAddress]]`localAddress`|`String`|
++++
+Set the local interface to bind for network connections. When the local address is null,
+ it will pick any local address, the default local address is null.
++++
 |[[logActivity]]`logActivity`|`Boolean`|
 +++
 Set to true to enabled network activity logging: Netty's pipeline is configured for logging on Netty's logger.
@@ -718,6 +723,11 @@ Set whether keep alive is enabled on the client
 +++
 Set the key/cert options in jks format, aka Java keystore.
 +++
+|[[localAddress]]`localAddress`|`String`|
++++
+Set the local interface to bind for network connections. When the local address is null,
+ it will pick any local address, the default local address is null.
++++
 |[[logActivity]]`logActivity`|`Boolean`|
 +++
 Set to true to enabled network activity logging: Netty's pipeline is configured for logging on Netty's logger.
@@ -1131,6 +1141,11 @@ Set the idle timeout, in seconds. zero means don't timeout.
 |[[keyStoreOptions]]`keyStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
 +++
 Set the key/cert options in jks format, aka Java keystore.
++++
+|[[localAddress]]`localAddress`|`String`|
++++
+Set the local interface to bind for network connections. When the local address is null,
+ it will pick any local address, the default local address is null.
 +++
 |[[logActivity]]`logActivity`|`Boolean`|
 +++

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -873,9 +873,34 @@ Set whether client auth is required
 +++
 Set whether client auth is required
 +++
+|[[compressionLevel]]`compressionLevel`|`Number (int)`|
++++
+This method allows to set the compression level to be used in http1.x/2 response bodies 
+ when compression support is turned on (@see setCompressionSupported) and the client advertises
+ to support <code>deflate/gzip</code> compression in the <code>Accept-Encoding</code> header
+ 
+ default value is : 6 (Netty legacy)
+ 
+ The compression level determines how much the data is compressed on a scale from 1 to 9,
+ where '9' is trying to achieve the maximum compression ratio while '1' instead is giving
+ priority to speed instead of compression ratio using some algorithm optimizations and skipping 
+ pedantic loops that usually gives just little improvements
+ 
+ While one can think that best value is always the maximum compression ratio, 
+ there's a trade-off to consider: the most compressed level requires the most
+ computatinal work to compress/decompress data, e.g. more dictionary lookups and loops.
+ 
+ E.g. you have it set fairly high on a high-volume website, you may experience performance degradation 
+ and latency on resource serving due to CPU overload, and, however - as the comptational work is required also client side 
+ while decompressing - setting an higher compression level can result in an overall higher page load time
+ especially nowadays when many clients are handled mobile devices with a low CPU profile.
+ 
+ see also: http://www.gzip.org/algorithm.txt
++++
 |[[compressionSupported]]`compressionSupported`|`Boolean`|
 +++
-Set whether the server supports compression
+Set whether the server should support gzip/deflate compression 
+ (serving compressed responses to clients advertising support for them with Accept-Encoding header)
 +++
 |[[crlPaths]]`crlPaths`|`Array of String`|
 +++
@@ -884,6 +909,10 @@ Add a CRL path
 |[[crlValues]]`crlValues`|`Array of Buffer`|
 +++
 Add a CRL value
++++
+|[[decompressionSupported]]`decompressionSupported`|`Boolean`|
++++
+Set whether the server supports decompression
 +++
 |[[enabledCipherSuites]]`enabledCipherSuites`|`Array of String`|
 +++

--- a/src/main/asciidoc/js/filesystem.adoc
+++ b/src/main/asciidoc/js/filesystem.adoc
@@ -139,7 +139,7 @@ vertx.fileSystem().open("target/classes/hello.txt", {
   if (result_err == null) {
     var file = result;
     var buff = Buffer.buffer("foo");
-    for (var i = 0; i < 5; i++) {
+    for (var i = 0;i < 5;i++) {
       file.write(buff, buff.length() * i, function (ar, ar_err) {
         if (ar_err == null) {
           console.log("Written ok!");
@@ -182,7 +182,7 @@ vertx.fileSystem().open("target/classes/les_miserables.txt", {
   if (result_err == null) {
     var file = result;
     var buff = Buffer.buffer(1000);
-    for (var i = 0; i < 10; i++) {
+    for (var i = 0;i < 10;i++) {
       file.read(buff, i * 100, i * 100, 100, function (ar, ar_err) {
         if (ar_err == null) {
           console.log("Read ok!");

--- a/src/main/asciidoc/js/http.adoc
+++ b/src/main/asciidoc/js/http.adoc
@@ -1232,7 +1232,7 @@ no need to set the `Content-Length` of the request up-front.
 request.setChunked(true);
 
 // Write some chunks
-for (var i = 0; i < 10; i++) {
+for (var i = 0;i < 10;i++) {
   request.write("this-is-chunk-" + i);
 }
 
@@ -1885,7 +1885,7 @@ endpoint:
 ----
 var Buffer = require("vertx-js/buffer");
 var data = Buffer.buffer();
-for (var i = 0; i < 8; i++) {
+for (var i = 0;i < 8;i++) {
   data.appendByte(i);
 }
 connection.ping(data, function (pong, pong_err) {

--- a/src/main/asciidoc/js/http.adoc
+++ b/src/main/asciidoc/js/http.adoc
@@ -436,6 +436,16 @@ request.uploadHandler(function (upload) {
 WARNING: Make sure you check the filename in a production system to avoid malicious clients uploading files
 to arbitrary places on your filesystem. See <<Security notes, security notes>> for more information.
 
+==== Handling compressed body
+
+Vert.x can handle compressed body payloads which are encoded by the client with the _deflate_ or _gzip_
+algorithms.
+
+To enable decompression set `link:../dataobjects.html#HttpServerOptions#setDecompressionSupported[decompressionSupported]` on the
+options when creating the server.
+
+By default decompression is disabled.
+
 ==== Receiving custom HTTP/2 frames
 
 HTTP/2 is a framed protocol with various frames for the HTTP request/response model. The protocol allows other kind
@@ -874,6 +884,21 @@ If such a header is found the server will automatically compress the body of the
 compressions and send it back to the client.
 
 Be aware that compression may be able to reduce network traffic but is more CPU-intensive.
+
+To address this latter issue Vert.x allows you to tune the 'compression level' parameter that is native of the gzip/deflate compression algorithms. 
+
+Compression level allows to configure gizp/deflate algorithms in terms of the compression ratio of the resulting data and the computational cost of the compress/decompress operation. 
+
+The compression level is an integer value ranged from '1' to '9', where '1' means lower compression ratio but fastest algorithm and '9' means maximum compression ratio available but a slower algorithm. 
+
+Using compression levels higher that 1-2 usually allows to save just some bytes in size - the gain is not linear, and depends on the specific data to be compressed 
+- but it comports a non-trascurable cost in term of CPU cycles required to the server while generating the compressed response data 
+( Note that at moment Vert.x doesn't support any form caching of compressed response data, even for static files, so the compression is done on-the-fly 
+at every request body generation ) and in the same way it affects client(s) while decoding (inflating) received responses, operation that becomes more CPU-intensive 
+the more the level increases.
+
+By default - if compression is enabled via `link:../dataobjects.html#HttpServerOptions#setCompressionSupported[compressionSupported]` - Vert.x will use '6' as compression level,
+but the parameter can be configured to address any case with `link:../dataobjects.html#HttpServerOptions#setCompressionLevel[compressionLevel]`.
 
 === Creating an HTTP client
 

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -475,8 +475,7 @@ fut1.compose(function (v) {
   return fut2
 }).compose(function (v) {
   // When the file is written (fut2), execute this:
-  var fut3 = Future.future();
-  fs.move("/foo", "/bar", fut3.completer());
+  fs.move("/foo", "/bar", startFuture.completer());
 }, startFuture);
 
 ----
@@ -485,10 +484,10 @@ In this example, 3 operations are chained:
 
 1. a file is created (`fut1`)
 2. something is written in the file (`fut2`)
-3. the file is moved (`fut3`)
+3. the file is moved (`startFuture`)
 
-When these 3 steps are successful, the final future (`startFuture`) is completed with a success. However, if one
-of the steps fails, the final future is completed with a failure.
+When these 3 steps are successful, the final future (`startFuture`) is succeeded. However, if one
+of the steps fails, the final future is failed.
 
 This example uses:
 
@@ -1555,7 +1554,7 @@ To specify an HA group you use the `-hagroup` switch when running the verticle, 
 
 [source]
 ----
-vertx run my-verticle.js -ha -ha-group my-group
+vertx run my-verticle.js -ha -hagroup my-group
 ----
 
 Let's look at an example:

--- a/src/main/asciidoc/js/net.adoc
+++ b/src/main/asciidoc/js/net.adoc
@@ -269,7 +269,7 @@ You can instantiate more instances programmatically in your code:
 
 // Create a few instances so we can utilise cores
 
-for (var i = 0; i < 10; i++) {
+for (var i = 0;i < 10;i++) {
   var server = vertx.createNetServer();
   server.connectHandler(function (socket) {
     socket.handler(function (buffer) {

--- a/src/main/asciidoc/js/net.adoc
+++ b/src/main/asciidoc/js/net.adoc
@@ -435,7 +435,7 @@ The logger implementation can be forced to a specific implementation by setting 
 
 [source,java]
 ----
-// Force logging to SLF4J
+// Force logging to Log4j
 InternalLoggerFactory.setDefaultFactory(Log4JLoggerFactory.INSTANCE);
 ----
 

--- a/src/main/resources/vertx-js/template/common.templ
+++ b/src/main/resources/vertx-js/template/common.templ
@@ -141,9 +141,9 @@ utils.convParamJsonArray(@{unwrappedName})
 			@if{unwrappedType.classParam}
 j_@{unwrappedType.name}.unwrap(@{unwrappedName})
 			@else{}
-				@code{typeLiteralParam=method.resolveTypeLiteralParam(unwrappedType)}
-				@if{typeLiteralParam != null}
-utils.get_jtype(@{typeLiteralParam.name}).unwrap(@{unwrappedName})
+				@code{classTypeParam=method.resolveClassTypeParam(unwrappedType)}
+				@if{classTypeParam != null}
+utils.get_jtype(@{classTypeParam.name}).unwrap(@{unwrappedName})
 				@else{}
 utils.convParamTypeUnknown(@{unwrappedName})
 				@end{}
@@ -211,7 +211,7 @@ utils.convParamSetEnum(@{unwrappedName}, function(val) { return Packages.@{unwra
 		@else{}
 @if{param.nullable}@{unwrappedName} == null ? null : @end{}utils.convParamSetBasicOther(@{unwrappedName})
 		@end{}
-	@else{unwrappedType.kind == CLASS_TYPE_LITERAL}
+	@else{unwrappedType.kind == CLASS_CLASS_TYPE}
 		utils.get_jclass(@{unwrappedName})
 	@else{unwrappedType.kind == CLASS_MAP}
 		@if{unwrappedType.args[1].name == 'long' || unwrappedType.args[1].name == 'java.lang.Long'}
@@ -302,7 +302,7 @@ ar.result()
 						@if{param.nullable}(@end{}
 						typeof __args[@{cnt}] === 'string'
 						@if{param.nullable} || __args[@{cnt}] == null)@end{}
-					@else{param.type.kind == CLASS_TYPE_LITERAL}
+					@else{param.type.kind == CLASS_CLASS_TYPE}
 						typeof __args[@{cnt}] === 'function'
 					@else{param.type.kind == CLASS_API}
 						typeof __args[@{cnt}] === 'object' && @if{param.nullable}(__args[@{cnt}] == null || @end{}__args[@{cnt}]._jdel@if{param.nullable})@end{}

--- a/src/main/resources/vertx-js/template/common.templ
+++ b/src/main/resources/vertx-js/template/common.templ
@@ -89,9 +89,6 @@
 @comment{"Generate the code that converts a parameter from JavaScript to Java to call a Java API method"}
 @comment{"============================================================================================="}
 
-@declare{'susmab'}
-@end{}
-
 @declare{'convParam'}
 	@code{paramName = overloaded ? argName : param.name;}
 	@code{funct = param.type.kind == CLASS_FUNCTION}
@@ -140,7 +137,20 @@ utils.convParamJsonArray(@{unwrappedName})
 	@else{unwrappedType.kind == CLASS_ENUM}
 @if{param.nullable}@{unwrappedName} == null ? null : @end{}@{unwrappedType.name}.valueOf(@{unwrappedName})
 	@else{unwrappedType.kind == CLASS_OBJECT}
+		@if{unwrappedType.variable}
+			@if{unwrappedType.classParam}
+j_@{unwrappedType.name}.unwrap(@{unwrappedName})
+			@else{}
+				@code{typeLiteralParam=method.resolveTypeLiteralParam(unwrappedType)}
+				@if{typeLiteralParam != null}
+utils.get_jtype(@{typeLiteralParam.name}).unwrap(@{unwrappedName})
+				@else{}
 utils.convParamTypeUnknown(@{unwrappedName})
+				@end{}
+			@end{}
+		@else{}
+utils.convParamTypeUnknown(@{unwrappedName})
+		@end{}
 	@else{unwrappedType.kind.basic}
 		@if{unwrappedType.name == 'java.lang.Byte'}
 utils.convParamByte(@{unwrappedName})
@@ -202,7 +212,7 @@ utils.convParamSetEnum(@{unwrappedName}, function(val) { return Packages.@{unwra
 @if{param.nullable}@{unwrappedName} == null ? null : @end{}utils.convParamSetBasicOther(@{unwrappedName})
 		@end{}
 	@else{unwrappedType.kind == CLASS_TYPE_LITERAL}
-		utils.javaTypeOf(@{unwrappedName})
+		utils.get_jclass(@{unwrappedName})
 	@else{unwrappedType.kind == CLASS_MAP}
 		@if{unwrappedType.args[1].name == 'long' || unwrappedType.args[1].name == 'java.lang.Long'}
 utils.convParamMapLong(@{unwrappedName})
@@ -303,7 +313,11 @@ ar.result()
 							typeof __args[@{cnt}] === 'function'
 						@if{param.nullable} || __args[@{cnt}] == null)@end{}
 					@else{param.type.kind == CLASS_OBJECT}
-						typeof __args[@{cnt}] !== 'function'
+						@if{param.type.variable && param.type.classParam}
+							j_@{param.type.name}.accept(__args[@{cnt}])
+						@else{}
+							typeof __args[@{cnt}] !== 'function'
+						@end{}
 					@else{param.type.kind == CLASS_FUNCTION}
 						typeof __args[@{cnt}] === 'function'
 					@else{param.type.kind == CLASS_THROWABLE}

--- a/src/main/resources/vertx-js/template/common.templ
+++ b/src/main/resources/vertx-js/template/common.templ
@@ -201,6 +201,8 @@ utils.convParamSetEnum(@{unwrappedName}, function(val) { return Packages.@{unwra
 		@else{}
 @if{param.nullable}@{unwrappedName} == null ? null : @end{}utils.convParamSetBasicOther(@{unwrappedName})
 		@end{}
+	@else{unwrappedType.kind == CLASS_TYPE_LITERAL}
+		utils.javaTypeOf(@{unwrappedName})
 	@else{unwrappedType.kind == CLASS_MAP}
 		@if{unwrappedType.args[1].name == 'long' || unwrappedType.args[1].name == 'java.lang.Long'}
 utils.convParamMapLong(@{unwrappedName})
@@ -290,6 +292,8 @@ ar.result()
 						@if{param.nullable}(@end{}
 						typeof __args[@{cnt}] === 'string'
 						@if{param.nullable} || __args[@{cnt}] == null)@end{}
+					@else{param.type.kind == CLASS_TYPE_LITERAL}
+						typeof __args[@{cnt}] === 'function'
 					@else{param.type.kind == CLASS_API}
 						typeof __args[@{cnt}] === 'object' && @if{param.nullable}(__args[@{cnt}] == null || @end{}__args[@{cnt}]._jdel@if{param.nullable})@end{}
 					@else{param.type.kind == CLASS_JSON_ARRAY || param.type.kind == CLASS_LIST || param.type.kind == CLASS_SET}

--- a/src/main/resources/vertx-js/template/js.templ
+++ b/src/main/resources/vertx-js/template/js.templ
@@ -65,7 +65,24 @@ utils.convReturnLong(@includeNamed{templ})
 @includeNamed{templ}
 		@end{}
 	@else{returnType.kind == CLASS_API}
-utils.convReturnVertxGen(@includeNamed{templ}, @{returnType.raw.simpleName})
+utils.convReturnVertxGen(@{returnType.raw.simpleName}, @includeNamed{templ}
+		@if{returnType.parameterized}
+			@foreach{arg:returnType.args}
+				@if{arg.kind == CLASS_API}
+					, @{arg.simpleName}._create
+				@else{arg.kind == CLASS_OBJECT}
+					@code{typeLiteralParam=method.resolveTypeLiteralParam(arg)}
+					@if{typeLiteralParam != null}
+						, __args[@{typeLiteralParam.index}]._create
+					@else{}
+						, undefined
+					@end{}
+				@else{}
+					, undefined
+				@end{}
+			@end{}
+		@end{}
+)
 	@else{returnType.kind == CLASS_ENUM}
 utils.convReturnEnum(@includeNamed{templ})
 	@else{returnType.kind == CLASS_DATA_OBJECT}
@@ -80,7 +97,13 @@ utils.convReturnHandler(@includeNamed{templ}, function(result) { return @include
 		@end{}
 	@else{}
 	@comment{'This will probably happen if the return type is generic'}
-utils.convReturnTypeUnknown(@includeNamed{templ})
+		@code{wrapper='utils.convReturnTypeUnknown'}
+		@foreach{param: type.params}
+			@if{param.name == returnType.name}
+				@code{wrapper='j_' + param.name}
+			@end{}
+		@end{}
+@{wrapper}(@includeNamed{templ})
 	@end{}
 @end{}
 
@@ -160,9 +183,12 @@ var @{dataObjectType.simpleName} = @{dataObjectType};\n
 
 @comment{"The constructor"}
 
-var @{ifaceSimpleName} = function(j_val) {\n\n
+var @{ifaceSimpleName} = function(j_val@foreach{param: type.params}, j_arg_@{param.index}@end{}) {\n\n
   var j_@{ifaceName} = j_val;\n
   var that = this;\n
+@foreach{param: type.params}
+  var j_@{param.name} = typeof j_arg_@{param.index} === 'function' ? j_arg_@{param.index} : utils.convReturnTypeUnknown;\n
+@end{}
 
 @comment{"Apply any supertypes"}
 
@@ -188,6 +214,15 @@ var @{ifaceSimpleName} = function(j_val) {\n\n
   this._jdel = j_@{ifaceName};\n
 };\n
 \n
+
+@{ifaceSimpleName}._jclass = utils.getJavaClass("@{type.raw.name}");\n
+
+@{ifaceSimpleName}._create = function(jdel) {\n
+  // A bit of jiggery pokery to create the object given a reference to the constructor function\n
+  var obj = Object.create(@{ifaceSimpleName}.prototype, {});\n
+  @{ifaceSimpleName}.apply(obj, arguments);\n
+  return obj;\n
+}\n
 
 @comment{"Iterate through the methods again, this time only considering the static ones"}
 

--- a/src/main/resources/vertx-js/template/js.templ
+++ b/src/main/resources/vertx-js/template/js.templ
@@ -73,9 +73,9 @@ utils.convReturnVertxGen(@{returnType.raw.simpleName}, @includeNamed{templ}
 				@else{arg.kind == CLASS_ENUM}
 					, utils.enum_jtype(@{arg.name})
 				@else{arg.kind == CLASS_OBJECT}
-					@code{typeLiteralParam=method.resolveTypeLiteralParam(arg)}
-					@if{typeLiteralParam != null}
-						, utils.get_jtype(@{typeLiteralParam.name})
+					@code{classTypeParam=method.resolveClassTypeParam(arg)}
+					@if{classTypeParam != null}
+						, utils.get_jtype(@{classTypeParam.name})
 					@else{}
 						, undefined
 					@end{}

--- a/src/main/resources/vertx-js/template/js.templ
+++ b/src/main/resources/vertx-js/template/js.templ
@@ -97,6 +97,8 @@ utils.convReturnHandlerAsyncResult(@includeNamed{templ}, function(result) { retu
 		@else{}
 utils.convReturnHandler(@includeNamed{templ}, function(result) { return @includeNamed{'convParam';overloaded=false;param=new io.vertx.codegen.ParamInfo(0, "result", null, returnType.args[0])}; })
 		@end{}
+	@else{returnType.variable && method != null  && (classTypeParam = method.resolveClassTypeParam(returnType)) != null}
+utils.get_jtype(@{classTypeParam.name}).wrap(@includeNamed{templ})
 	@else{}
 	@comment{'This will probably happen if the return type is generic'}
 		@code{wrapper='utils.convReturnTypeUnknown'}

--- a/src/main/resources/vertx-js/template/js.templ
+++ b/src/main/resources/vertx-js/template/js.templ
@@ -70,6 +70,8 @@ utils.convReturnVertxGen(@{returnType.raw.simpleName}, @includeNamed{templ}
 			@foreach{arg:returnType.args}
 				@if{arg.kind == CLASS_API}
 					, @{arg.simpleName}._jtype
+				@else{arg.kind == CLASS_ENUM}
+					, utils.enum_jtype(@{arg.name})
 				@else{arg.kind == CLASS_OBJECT}
 					@code{typeLiteralParam=method.resolveTypeLiteralParam(arg)}
 					@if{typeLiteralParam != null}

--- a/src/main/resources/vertx-js/template/js.templ
+++ b/src/main/resources/vertx-js/template/js.templ
@@ -69,11 +69,11 @@ utils.convReturnVertxGen(@{returnType.raw.simpleName}, @includeNamed{templ}
 		@if{returnType.parameterized}
 			@foreach{arg:returnType.args}
 				@if{arg.kind == CLASS_API}
-					, @{arg.simpleName}._create
+					, @{arg.simpleName}._jtype
 				@else{arg.kind == CLASS_OBJECT}
 					@code{typeLiteralParam=method.resolveTypeLiteralParam(arg)}
 					@if{typeLiteralParam != null}
-						, __args[@{typeLiteralParam.index}]._create
+						, utils.get_jtype(@{typeLiteralParam.name})
 					@else{}
 						, undefined
 					@end{}
@@ -100,7 +100,7 @@ utils.convReturnHandler(@includeNamed{templ}, function(result) { return @include
 		@code{wrapper='utils.convReturnTypeUnknown'}
 		@foreach{param: type.params}
 			@if{param.name == returnType.name}
-				@code{wrapper='j_' + param.name}
+				@code{wrapper='j_' + param.name + '.wrap'}
 			@end{}
 		@end{}
 @{wrapper}(@includeNamed{templ})
@@ -187,13 +187,23 @@ var @{ifaceSimpleName} = function(j_val@foreach{param: type.params}, j_arg_@{par
   var j_@{ifaceName} = j_val;\n
   var that = this;\n
 @foreach{param: type.params}
-  var j_@{param.name} = typeof j_arg_@{param.index} === 'function' ? j_arg_@{param.index} : utils.convReturnTypeUnknown;\n
+  var j_@{param.name} = typeof j_arg_@{param.index} !== 'undefined' ? j_arg_@{param.index} : utils.unknown_jtype;\n
 @end{}
 
 @comment{"Apply any supertypes"}
 
 @foreach{superType: superTypes}
-  @{superType.raw.simpleName}.call(this, j_val);\n
+  @{superType.raw.simpleName}.call(this, j_val@if{superType.parameterized && superType.raw.concrete}
+	@foreach{arg:superType.args}
+		@if{arg.kind == CLASS_API}
+, @{arg.simpleName}._jtype
+		@else{arg.variable}
+, j_@{arg.name}
+		@else{}
+, undefined
+		@end{}
+	@end{}
+@end{});\n
 @end{}
 \n
 
@@ -216,6 +226,22 @@ var @{ifaceSimpleName} = function(j_val@foreach{param: type.params}, j_arg_@{par
 \n
 
 @{ifaceSimpleName}._jclass = utils.getJavaClass("@{type.raw.name}");\n
+
+@{ifaceSimpleName}._jtype = {\n
+  accept: function(obj) {\n
+    return @{ifaceSimpleName}._jclass.isInstance(obj._jdel);\n
+  },\n
+  wrap: function(jdel) {\n
+    // A bit of jiggery pokery to create the object given a reference to the constructor function\n
+    var obj = Object.create(@{ifaceSimpleName}.prototype, {});\n
+    @{ifaceSimpleName}.apply(obj, arguments);\n
+    return obj;\n
+  },\n
+  unwrap: function(obj) {\n
+    return obj._jdel;\n
+  }\n
+};\n
+
 
 @{ifaceSimpleName}._create = function(jdel) {\n
   // A bit of jiggery pokery to create the object given a reference to the constructor function\n

--- a/src/main/resources/vertx-js/template/js.templ
+++ b/src/main/resources/vertx-js/template/js.templ
@@ -236,7 +236,7 @@ var @{ifaceSimpleName} = function(j_val@foreach{param: type.params}, j_arg_@{par
     return @{ifaceSimpleName}._jclass.isInstance(obj._jdel);\n
   },\n
   wrap: function(jdel) {\n
-    // A bit of jiggery pokery to create the object given a reference to the constructor function\n
+		@comment{'A bit of jiggery pokery to create the object given a reference to the constructor function'}
     var obj = Object.create(@{ifaceSimpleName}.prototype, {});\n
     @{ifaceSimpleName}.apply(obj, arguments);\n
     return obj;\n
@@ -248,7 +248,7 @@ var @{ifaceSimpleName} = function(j_val@foreach{param: type.params}, j_arg_@{par
 
 
 @{ifaceSimpleName}._create = function(jdel) {\n
-  // A bit of jiggery pokery to create the object given a reference to the constructor function\n
+		@comment{'A bit of jiggery pokery to create the object given a reference to the constructor function'}
   var obj = Object.create(@{ifaceSimpleName}.prototype, {});\n
   @{ifaceSimpleName}.apply(obj, arguments);\n
   return obj;\n
@@ -263,5 +263,5 @@ var @{ifaceSimpleName} = function(j_val@foreach{param: type.params}, j_arg_@{par
 
 @end{}
 
-// We export the Constructor function\n
+@comment{'We export the Constructor function'}
 module.exports = @{ifaceSimpleName};

--- a/src/main/resources/vertx-js/util/utils.js
+++ b/src/main/resources/vertx-js/util/utils.js
@@ -310,13 +310,30 @@ utils.convReturnListSetJson = function(jList) {
   return arr;
 };
 
+utils.getJavaClass = function(fqn) {
+  var type = Java.type(fqn + "[]");
+  return new type(0).getClass().getComponentType();
+};
+
+utils.typeMap = [
+  utils.getJavaClass("io.vertx.core.json.JsonObject")
+];
+
+utils.javaTypeOf = function(type) {
+  var jclass = type._jclass;
+  if (jclass != null) {
+    return jclass;
+  } else if (type === Object) {
+    return utils.typeMap[0];
+  } else {
+    return null;
+  }
+};
+
 // Convert a VertxGen return value
-utils.convReturnVertxGen = function(jdel, constructorFunction) {
+utils.convReturnVertxGen = function(constructorFunction, jdel) {
   if (jdel != null) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
-    var obj = Object.create(constructorFunction.prototype, {});
-    constructorFunction.apply(obj, [jdel]);
-    return obj;
+    return constructorFunction._create.apply(this, Array.prototype.slice.call(arguments, 1));
   }
   return null;
 }

--- a/src/main/resources/vertx-js/util/utils.js
+++ b/src/main/resources/vertx-js/util/utils.js
@@ -315,19 +315,19 @@ utils.getJavaClass = function(fqn) {
   return new type(0).getClass().getComponentType();
 };
 
-utils.typeMap = [
-  utils.getJavaClass("io.vertx.core.json.JsonObject")
-];
+utils.typeMap = {};
+utils.typeMap[Object] = utils.getJavaClass("io.vertx.core.json.JsonObject");
+utils.typeMap[Array] = utils.getJavaClass("io.vertx.core.json.JsonArray");
+utils.typeMap[Number] = utils.getJavaClass("java.lang.Long");
+utils.typeMap[String] = utils.getJavaClass("java.lang.String");
+utils.typeMap[Boolean] = utils.getJavaClass("java.lang.Boolean");
 
 utils.get_jclass = function(type) {
   var jclass = type._jclass;
-  if (jclass != null) {
-    return jclass;
-  } else if (type === Object) {
-    return utils.typeMap[0];
-  } else {
-    return null;
+  if (jclass == null) {
+    jclass = utils.typeMap[type];
   }
+  return jclass;
 };
 
 utils.get_jtype = function(t) {
@@ -337,7 +337,6 @@ utils.get_jtype = function(t) {
     return t._jtype;
   }
 }
-
 
 // Convert a VertxGen return value
 utils.convReturnVertxGen = function(constructorFunction, jdel) {
@@ -523,5 +522,16 @@ utils.unknown_jtype = {
   wrap: utils.convReturnTypeUnknown,
   unwrap: utils.convParamTypeUnknown
 }
+
+utils.enum_jtype = function(jEnum) {
+  return {
+    accept: function(val) {
+      return typeof val === 'string';
+    },
+    wrap: utils.convReturnEnum,
+    unwrap: jEnum.valueOf
+  };
+}
+
 
 module.exports = utils;

--- a/src/main/resources/vertx-js/util/utils.js
+++ b/src/main/resources/vertx-js/util/utils.js
@@ -319,7 +319,7 @@ utils.typeMap = [
   utils.getJavaClass("io.vertx.core.json.JsonObject")
 ];
 
-utils.javaTypeOf = function(type) {
+utils.get_jclass = function(type) {
   var jclass = type._jclass;
   if (jclass != null) {
     return jclass;
@@ -329,6 +329,15 @@ utils.javaTypeOf = function(type) {
     return null;
   }
 };
+
+utils.get_jtype = function(t) {
+  if (typeof t._jtype === 'undefined') {
+    return utils.unknown_jtype;
+  } else {
+    return t._jtype;
+  }
+}
+
 
 // Convert a VertxGen return value
 utils.convReturnVertxGen = function(constructorFunction, jdel) {
@@ -505,5 +514,14 @@ utils.convReturnHandler = function(handler, converter) {
     handler.handle(converter(result));
   }
 };
+
+//
+utils.unknown_jtype = {
+  accept: function(obj) {
+    return typeof obj !== 'function';
+  },
+  wrap: utils.convReturnTypeUnknown,
+  unwrap: utils.convParamTypeUnknown
+}
 
 module.exports = utils;

--- a/src/test/java/io/vertx/test/lang/js/GenericsTCKTest.java
+++ b/src/test/java/io/vertx/test/lang/js/GenericsTCKTest.java
@@ -169,11 +169,6 @@ public class GenericsTCKTest extends JSTestBase {
   }
 
   @Test
-  public void testFooBar() throws Exception {
-    runTest();
-  }
-
-  @Test
   public void testInterfaceWithStringArg() throws Exception {
     runTest();
   }

--- a/src/test/java/io/vertx/test/lang/js/GenericsTCKTest.java
+++ b/src/test/java/io/vertx/test/lang/js/GenericsTCKTest.java
@@ -32,4 +32,19 @@ public class GenericsTCKTest extends JSTestBase {
   public void testMethodWithHandlerClassTypeParameterized() throws Exception {
     runTest();
   }
+
+  @Test
+  public void testInterfaceWithStringArg() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testInterfaceWithVariableArg() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testInterfaceWithApiArg() throws Exception {
+    runTest();
+  }
 }

--- a/src/test/java/io/vertx/test/lang/js/GenericsTCKTest.java
+++ b/src/test/java/io/vertx/test/lang/js/GenericsTCKTest.java
@@ -1,0 +1,35 @@
+package io.vertx.test.lang.js;
+
+import org.junit.Test;
+
+/**
+ *
+ * This test tests all the different types of methods, return values and parameters that can be used in generated
+ * APIs.
+ *
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public class GenericsTCKTest extends JSTestBase {
+
+  @Override
+  protected String getTestFile() {
+    return "generics_tck_test.js";
+  }
+
+  // Test params
+
+  @Test
+  public void testMethodWithUserTypeParameterizedReturn() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithClassTypeParameterizedReturn() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerClassTypeParameterized() throws Exception {
+    runTest();
+  }
+}

--- a/src/test/java/io/vertx/test/lang/js/GenericsTCKTest.java
+++ b/src/test/java/io/vertx/test/lang/js/GenericsTCKTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
  * This test tests all the different types of methods, return values and parameters that can be used in generated
  * APIs.
  *
- * @author <a href="http://tfox.org">Tim Fox</a>
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class GenericsTCKTest extends JSTestBase {
 

--- a/src/test/java/io/vertx/test/lang/js/GenericsTCKTest.java
+++ b/src/test/java/io/vertx/test/lang/js/GenericsTCKTest.java
@@ -34,6 +34,11 @@ public class GenericsTCKTest extends JSTestBase {
   }
 
   @Test
+  public void testMethodWithFunctionParamBasicParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
   public void testMethodWithJsonParameterizedReturn() throws Exception {
     runTest();
   }
@@ -45,6 +50,11 @@ public class GenericsTCKTest extends JSTestBase {
 
   @Test
   public void testMethodWithHandlerAsyncResultJsonParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithFunctionParamJsonParameterized() throws Exception {
     runTest();
   }
 
@@ -64,6 +74,11 @@ public class GenericsTCKTest extends JSTestBase {
   }
 
   @Test
+  public void testMethodWithFunctionParamDataObjectParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
   public void testMethodWithEnumParameterizedReturn() throws Exception {
     runTest();
   }
@@ -75,6 +90,11 @@ public class GenericsTCKTest extends JSTestBase {
 
   @Test
   public void testMethodWithHandlerAsyncResultEnumParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithFunctionParamEnumParameterized() throws Exception {
     runTest();
   }
 
@@ -94,6 +114,11 @@ public class GenericsTCKTest extends JSTestBase {
   }
 
   @Test
+  public void testMethodWithFunctionParamUserTypeParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
   public void testMethodWithClassTypeParameterizedReturn() throws Exception {
     runTest();
   }
@@ -108,8 +133,45 @@ public class GenericsTCKTest extends JSTestBase {
     runTest();
   }
 
+  @Test
+  public void testMethodWithFunctionParamClassTypeParameterized() throws Exception {
+    runTest();
+  }
 
-  
+  @Test
+  public void testMethodWithClassTypeParam() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithClassTypeReturn() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithClassTypeHandler() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithClassTypeHandlerAsyncResult() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithClassTypeFunctionParam() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithClassTypeFunctionReturn() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testFooBar() throws Exception {
+    runTest();
+  }
 
   @Test
   public void testInterfaceWithStringArg() throws Exception {

--- a/src/test/java/io/vertx/test/lang/js/GenericsTCKTest.java
+++ b/src/test/java/io/vertx/test/lang/js/GenericsTCKTest.java
@@ -19,7 +19,77 @@ public class GenericsTCKTest extends JSTestBase {
   // Test params
 
   @Test
+  public void testMethodWithBasicParameterizedReturn() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerBasicParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultBasicParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithJsonParameterizedReturn() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerJsonParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultJsonParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithDataObjectParameterizedReturn() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerDataObjectParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultDataObjectParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithEnumParameterizedReturn() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerEnumParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultEnumParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
   public void testMethodWithUserTypeParameterizedReturn() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerUserTypeParameterized() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultUserTypeParameterized() throws Exception {
     runTest();
   }
 
@@ -32,6 +102,14 @@ public class GenericsTCKTest extends JSTestBase {
   public void testMethodWithHandlerClassTypeParameterized() throws Exception {
     runTest();
   }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultClassTypeParameterized() throws Exception {
+    runTest();
+  }
+
+
+  
 
   @Test
   public void testInterfaceWithStringArg() throws Exception {

--- a/src/test/resources/acme-js/my_interface.js
+++ b/src/test/resources/acme-js/my_interface.js
@@ -41,7 +41,7 @@ var MyInterface = function(j_val) {
   this.sub = function() {
     var __args = arguments;
     if (__args.length === 0) {
-      return utils.convReturnVertxGen(j_myInterface["sub()"](), SubInterface);
+      return utils.convReturnVertxGen(SubInterface, j_myInterface["sub()"]());
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -54,7 +54,7 @@ var MyInterface = function(j_val) {
   this.method = function() {
     var __args = arguments;
     if (__args.length === 0) {
-      return utils.convReturnVertxGen(j_myInterface["method()"](), TestInterface);
+      return utils.convReturnVertxGen(TestInterface, j_myInterface["method()"]());
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -64,6 +64,13 @@ var MyInterface = function(j_val) {
   this._jdel = j_myInterface;
 };
 
+MyInterface._jclass = utils.getJavaClass("com.acme.pkg.MyInterface");
+MyInterface._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(MyInterface.prototype, {});
+  MyInterface.apply(obj, arguments);
+  return obj;
+}
 /**
 
  @memberof module:acme-js/my_interface
@@ -73,7 +80,7 @@ var MyInterface = function(j_val) {
 MyInterface.create = function() {
   var __args = arguments;
   if (__args.length === 0) {
-    return utils.convReturnVertxGen(JMyInterface["create()"](), MyInterface);
+    return utils.convReturnVertxGen(MyInterface, JMyInterface["create()"]());
   } else throw new TypeError('function invoked with invalid arguments');
 };
 

--- a/src/test/resources/acme-js/my_interface.js
+++ b/src/test/resources/acme-js/my_interface.js
@@ -65,6 +65,20 @@ var MyInterface = function(j_val) {
 };
 
 MyInterface._jclass = utils.getJavaClass("com.acme.pkg.MyInterface");
+MyInterface._jtype = {
+  accept: function(obj) {
+    return MyInterface._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(MyInterface.prototype, {});
+    MyInterface.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 MyInterface._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(MyInterface.prototype, {});

--- a/src/test/resources/acme-js/my_interface.js
+++ b/src/test/resources/acme-js/my_interface.js
@@ -70,7 +70,6 @@ MyInterface._jtype = {
     return MyInterface._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(MyInterface.prototype, {});
     MyInterface.apply(obj, arguments);
     return obj;
@@ -80,7 +79,6 @@ MyInterface._jtype = {
   }
 };
 MyInterface._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(MyInterface.prototype, {});
   MyInterface.apply(obj, arguments);
   return obj;
@@ -98,5 +96,4 @@ MyInterface.create = function() {
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
-// We export the Constructor function
 module.exports = MyInterface;

--- a/src/test/resources/acme-js/sub_interface.js
+++ b/src/test/resources/acme-js/sub_interface.js
@@ -50,6 +50,20 @@ var SubInterface = function(j_val) {
 };
 
 SubInterface._jclass = utils.getJavaClass("com.acme.pkg.sub.SubInterface");
+SubInterface._jtype = {
+  accept: function(obj) {
+    return SubInterface._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(SubInterface.prototype, {});
+    SubInterface.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 SubInterface._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(SubInterface.prototype, {});

--- a/src/test/resources/acme-js/sub_interface.js
+++ b/src/test/resources/acme-js/sub_interface.js
@@ -49,5 +49,12 @@ var SubInterface = function(j_val) {
   this._jdel = j_subInterface;
 };
 
+SubInterface._jclass = utils.getJavaClass("com.acme.pkg.sub.SubInterface");
+SubInterface._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(SubInterface.prototype, {});
+  SubInterface.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = SubInterface;

--- a/src/test/resources/acme-js/sub_interface.js
+++ b/src/test/resources/acme-js/sub_interface.js
@@ -55,7 +55,6 @@ SubInterface._jtype = {
     return SubInterface._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(SubInterface.prototype, {});
     SubInterface.apply(obj, arguments);
     return obj;
@@ -65,10 +64,8 @@ SubInterface._jtype = {
   }
 };
 SubInterface._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(SubInterface.prototype, {});
   SubInterface.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = SubInterface;

--- a/src/test/resources/generics_tck_test.js
+++ b/src/test/resources/generics_tck_test.js
@@ -460,24 +460,6 @@ function checkMethodWithClassType(values) {
   Assert.assertEquals('foo', refed.getString());
 }
 
-function testFooBar() {
-
-  refed_obj.setString("foo");
-
-  obj.methodWithFunctionParamUserTypeParameterized(function(generic) {
-    Assert.assertNotEquals('undefined', typeof generic._jdel);
-    Assert.assertNotEquals('undefined', typeof generic.getValue()._jdel);
-  });
-
-  obj.methodWithClassTypeParam(RefedInterface1, refed_obj);
-  obj.methodWithClassTypeFunctionParam(RefedInterface1, function(val) {
-    Assert.assertNotEquals('undefined', typeof val._jdel);
-  });
-  obj.methodWithClassTypeFunctionReturn(RefedInterface1, function() {
-    return refed_obj;
-  });
-}
-
 function testInterfaceWithStringArg() {
   var ret = obj.interfaceWithStringArg('the_string_value');
   Assert.assertNotEquals('undefined', typeof ret._jdel);

--- a/src/test/resources/generics_tck_test.js
+++ b/src/test/resources/generics_tck_test.js
@@ -13,6 +13,12 @@ function testMethodWithUserTypeParameterizedReturn() {
   var val = ret.getValue();
   Assert.assertNotEquals('undefined', typeof val._jdel);
   Assert.assertEquals('foo', val.getString());
+
+  refed_obj.setString("the_string")
+  ret.setValue(refed_obj);
+  val = ret.getValue();
+  Assert.assertNotEquals('undefined', typeof val._jdel);
+  Assert.assertEquals('the_string', val.getString());
 }
 
 function testMethodWithClassTypeParameterizedReturn() {
@@ -22,10 +28,20 @@ function testMethodWithClassTypeParameterizedReturn() {
   Assert.assertNotEquals('undefined', typeof val._jdel);
   Assert.assertEquals('foo', val.getString());
 
+  refed_obj.setString("the_string")
+  ret.setValue(refed_obj);
+  val = ret.getValue();
+  Assert.assertNotEquals('undefined', typeof val._jdel);
+  Assert.assertEquals('the_string', val.getString());
+
   ret = obj.methodWithClassTypeParameterizedReturn(Object);
   Assert.assertNotEquals('undefined', typeof ret._jdel);
   val = ret.getValue();
   Assert.assertEquals("stilton", val["cheese"]);
+
+  ret.setValue({"wine":"condrieu"});
+  val = ret.getValue();
+  Assert.assertEquals("condrieu", val["wine"]);
 }
 
 function testMethodWithHandlerClassTypeParameterized() {
@@ -46,6 +62,38 @@ function testMethodWithHandlerClassTypeParameterized() {
     count++;
   });
   Assert.assertEquals(2, count, 0);
+}
+
+function testInterfaceWithStringArg() {
+  var ret = obj.interfaceWithStringArg('the_string_value');
+  Assert.assertNotEquals('undefined', typeof ret._jdel);
+  var val = ret.getValue();
+  Assert.assertEquals('string', typeof val);
+  Assert.assertEquals('the_string_value', val);
+}
+
+function testInterfaceWithVariableArg() {
+  refed_obj.setString('the_string_value');
+  var ret = obj.interfaceWithVariableArg('whatever', RefedInterface1, refed_obj);
+  Assert.assertNotEquals('undefined', typeof ret._jdel);
+  var val = ret.getValue();
+  Assert.assertNotEquals('undefined', typeof val._jdel);
+  Assert.assertEquals('the_string_value', val.getString());
+
+  var ret = obj.interfaceWithVariableArg('whatever', String, 'the_string_arg');
+  Assert.assertNotEquals('undefined', typeof ret._jdel);
+  var val = ret.getValue();
+  Assert.assertEquals('undefined', typeof val._jdel);
+  Assert.assertEquals('the_string_arg', val);
+}
+
+function testInterfaceWithApiArg() {
+  refed_obj.setString('the_string_value');
+  var ret = obj.interfaceWithApiArg(refed_obj);
+  Assert.assertNotEquals('undefined', typeof ret._jdel);
+  var val = ret.getValue();
+  Assert.assertNotEquals('undefined', typeof val._jdel);
+  Assert.assertEquals('the_string_value', val.getString());
 }
 
 if (typeof this[testName] === 'undefined') {

--- a/src/test/resources/generics_tck_test.js
+++ b/src/test/resources/generics_tck_test.js
@@ -79,6 +79,20 @@ function testMethodWithHandlerAsyncResultBasicParameterized() {
   checkMethodWithBasicParameterized(values);
 }
 
+function testMethodWithFunctionParamBasicParameterized() {
+  var values = [];
+  obj.methodWithFunctionParamByteParameterized(setter(values, 0));
+  obj.methodWithFunctionParamShortParameterized(setter(values, 1));
+  obj.methodWithFunctionParamIntegerParameterized(setter(values, 2));
+  obj.methodWithFunctionParamLongParameterized(setter(values, 3));
+  obj.methodWithFunctionParamFloatParameterized(setter(values, 4));
+  obj.methodWithFunctionParamDoubleParameterized(setter(values, 5));
+  obj.methodWithFunctionParamBooleanParameterized(setter(values, 6));
+  obj.methodWithFunctionParamCharacterParameterized(setter(values, 7));
+  obj.methodWithFunctionParamStringParameterized(setter(values, 8));
+  checkMethodWithBasicParameterized(values);
+}
+
 function checkMethodWithBasicParameterized(values) {
   var ret = assertApiType(values[0]);
   assertNumberEquals(ret.getValue(), 123);
@@ -139,6 +153,13 @@ function testMethodWithHandlerAsyncResultJsonParameterized() {
   checkMethodWitJsonParameterized(values);
 }
 
+function testMethodWithFunctionParamJsonParameterized() {
+  var values = [];
+  obj.methodWithFunctionParamJsonObjectParameterized(setter(values, 0));
+  obj.methodWithFunctionParamJsonArrayParameterized(setter(values, 1));
+  checkMethodWitJsonParameterized(values);
+}
+
 function checkMethodWitJsonParameterized(values) {
   var ret = assertApiType(values[0]);
   var val = ret.getValue();
@@ -173,6 +194,12 @@ function testMethodWithHandlerDataObjectParameterized() {
 function testMethodWithHandlerAsyncResultDataObjectParameterized() {
   var values = [];
   obj.methodWithHandlerAsyncResultDataObjectParameterized(asyncResultSetter(values, 0));
+  checkMethodWitDataObjectParameterized(values);
+}
+
+function testMethodWithFunctionParamDataObjectParameterized() {
+  var values = [];
+  obj.methodWithFunctionParamDataObjectParameterized(setter(values, 0));
   checkMethodWitDataObjectParameterized(values);
 }
 
@@ -211,6 +238,13 @@ function testMethodWithHandlerAsyncResultEnumParameterized() {
   checkMethodWithEnumParameterized(values);
 }
 
+function testMethodWithFunctionParamEnumParameterized() {
+  var values = [];
+  obj.methodWithFunctionParamEnumParameterized(setter(values, 0));
+  obj.methodWithFunctionParamGenEnumParameterized(setter(values, 1));
+  checkMethodWithEnumParameterized(values);
+}
+
 function checkMethodWithEnumParameterized(values) {
   var ret = assertApiType(values[0]);
   Assert.assertEquals(ret.getValue(), "WESTON");
@@ -235,6 +269,12 @@ function testMethodWithHandlerUserTypeParameterized() {
 function testMethodWithHandlerAsyncResultUserTypeParameterized() {
   var values = [];
   obj.methodWithHandlerAsyncResultUserTypeParameterized(setter(values, 0));
+  checkMethodWithUserTypeParameterized(values)
+}
+
+function testMethodWithFunctionParamUserTypeParameterized() {
+  var values = [];
+  obj.methodWithFunctionParamUserTypeParameterized(setter(values, 0));
   checkMethodWithUserTypeParameterized(values)
 }
 
@@ -285,6 +325,17 @@ function testMethodWithHandlerAsyncResultClassTypeParameterized() {
   checkMethodWithClassTypeParameterized(values);
 }
 
+function testMethodWithFunctionParamClassTypeParameterized() {
+  var values = [];
+  obj.methodWithFunctionParamClassTypeParameterized(Number, setter(values, 0));
+  obj.methodWithFunctionParamClassTypeParameterized(Boolean, setter(values, 1));
+  obj.methodWithFunctionParamClassTypeParameterized(String, setter(values, 2));
+  obj.methodWithFunctionParamClassTypeParameterized(Object, setter(values, 3));
+  obj.methodWithFunctionParamClassTypeParameterized(Array, setter(values, 4));
+  obj.methodWithFunctionParamClassTypeParameterized(RefedInterface1, setter(values, 5));
+  checkMethodWithClassTypeParameterized(values);
+}
+
 function checkMethodWithClassTypeParameterized(values) {
   var ret = values[0];
   Assert.assertNotEquals('undefined', typeof ret._jdel);
@@ -331,6 +382,100 @@ function checkMethodWithClassTypeParameterized(values) {
   val = ret.getValue();
   Assert.assertNotEquals('undefined', typeof val._jdel);
   Assert.assertEquals('the_string', val.getString());
+}
+
+function testMethodWithClassTypeParam() {
+  // obj.methodWithClassTypeParam(Number, 123456789);
+  obj.methodWithClassTypeParam(Boolean, true);
+  obj.methodWithClassTypeParam(String, "zoumbawe");
+  obj.methodWithClassTypeParam(Object, {"cheese":"stilton"});
+  obj.methodWithClassTypeParam(Array, ["cheese","stilton"]);
+  obj.methodWithClassTypeParam(RefedInterface1, refed_obj.setString("foo"));
+}
+
+function testMethodWithClassTypeReturn() {
+  checkMethodWithClassType([
+    obj.methodWithClassTypeReturn(Number),
+    obj.methodWithClassTypeReturn(Boolean),
+    obj.methodWithClassTypeReturn(String),
+    obj.methodWithClassTypeReturn(Object),
+    obj.methodWithClassTypeReturn(Array),
+    obj.methodWithClassTypeReturn(RefedInterface1)
+  ]);
+}
+
+function testMethodWithClassTypeHandler() {
+  var values = [];
+  obj.methodWithClassTypeHandler(Number, setter(values, 0));
+  obj.methodWithClassTypeHandler(Boolean, setter(values, 1));
+  obj.methodWithClassTypeHandler(String, setter(values, 2));
+  obj.methodWithClassTypeHandler(Object, setter(values, 3));
+  obj.methodWithClassTypeHandler(Array, setter(values, 4));
+  obj.methodWithClassTypeHandler(RefedInterface1, setter(values, 5));
+  checkMethodWithClassType(values);
+}
+
+function testMethodWithClassTypeHandlerAsyncResult() {
+  var values = [];
+  obj.methodWithClassTypeHandlerAsyncResult(Number, asyncResultSetter(values, 0));
+  obj.methodWithClassTypeHandlerAsyncResult(Boolean, asyncResultSetter(values, 1));
+  obj.methodWithClassTypeHandlerAsyncResult(String, asyncResultSetter(values, 2));
+  obj.methodWithClassTypeHandlerAsyncResult(Object, asyncResultSetter(values, 3));
+  obj.methodWithClassTypeHandlerAsyncResult(Array, asyncResultSetter(values, 4));
+  obj.methodWithClassTypeHandlerAsyncResult(RefedInterface1, asyncResultSetter(values, 5));
+  checkMethodWithClassType(values);
+}
+
+function testMethodWithClassTypeFunctionParam() {
+  var values = [];
+  obj.methodWithClassTypeFunctionParam(Number, setter(values, 0));
+  obj.methodWithClassTypeFunctionParam(Boolean, setter(values, 1));
+  obj.methodWithClassTypeFunctionParam(String, setter(values, 2));
+  obj.methodWithClassTypeFunctionParam(Object, setter(values, 3));
+  obj.methodWithClassTypeFunctionParam(Array, setter(values, 4));
+  obj.methodWithClassTypeFunctionParam(RefedInterface1, setter(values, 5));
+  checkMethodWithClassType(values);
+}
+
+function testMethodWithClassTypeFunctionReturn() {
+  // obj.methodWithClassTypeParam(Number, 123456789);
+  obj.methodWithClassTypeFunctionReturn(Boolean, function() { return true; });
+  obj.methodWithClassTypeFunctionReturn(String, function() { return "zoumbawe"; });
+  obj.methodWithClassTypeFunctionReturn(Object, function() { return {"cheese":"stilton"}; });
+  obj.methodWithClassTypeFunctionReturn(Array, function() { return ["cheese","stilton"]; });
+  obj.methodWithClassTypeFunctionReturn(RefedInterface1, function() { return refed_obj.setString("foo"); });
+}
+
+function checkMethodWithClassType(values) {
+  assertNumberEquals(values[0], 123456789);
+  Assert.assertEquals(true, values[1]);
+  Assert.assertEquals("zoumbawe", values[2]);
+  var jsonObject = values[3];
+  Assert.assertEquals("stilton", jsonObject["cheese"]);
+  var jsonArray = values[4];
+  Assert.assertEquals("cheese", jsonArray[0]);
+  Assert.assertEquals("stilton", jsonArray[1]);
+  var refed = values[5];
+  Assert.assertNotEquals('undefined', typeof refed._jdel);
+  Assert.assertEquals('foo', refed.getString());
+}
+
+function testFooBar() {
+
+  refed_obj.setString("foo");
+
+  obj.methodWithFunctionParamUserTypeParameterized(function(generic) {
+    Assert.assertNotEquals('undefined', typeof generic._jdel);
+    Assert.assertNotEquals('undefined', typeof generic.getValue()._jdel);
+  });
+
+  obj.methodWithClassTypeParam(RefedInterface1, refed_obj);
+  obj.methodWithClassTypeFunctionParam(RefedInterface1, function(val) {
+    Assert.assertNotEquals('undefined', typeof val._jdel);
+  });
+  obj.methodWithClassTypeFunctionReturn(RefedInterface1, function() {
+    return refed_obj;
+  });
 }
 
 function testInterfaceWithStringArg() {

--- a/src/test/resources/generics_tck_test.js
+++ b/src/test/resources/generics_tck_test.js
@@ -90,8 +90,8 @@ function checkMethodWithBasicParameterized(values) {
   assertNumberEquals(ret.getValue(), 1235);
   ret = assertApiType(values[2]);
   assertNumberEquals(ret.getValue(), 123456);
-  ret.setValue(1234568);
-  assertNumberEquals(ret.getValue(), 1234568);
+  ret.setValue(1234567);
+  assertNumberEquals(ret.getValue(), 1234567);
   ret = assertApiType(values[3]);
   assertNumberEquals(ret.getValue(), 123456789);
   ret.setValue(123456790);

--- a/src/test/resources/generics_tck_test.js
+++ b/src/test/resources/generics_tck_test.js
@@ -7,14 +7,245 @@ var obj = new GenericsTCK(new Packages.io.vertx.codegen.testmodel.GenericsTCKImp
 var refed_obj = new RefedInterface1(new Packages.io.vertx.codegen.testmodel.RefedInterface1Impl());
 var refed_obj2 = new RefedInterface1(new Packages.io.vertx.codegen.testmodel.RefedInterface1Impl());
 
+function assertApiType(obj) {
+  Assert.assertNotEquals('undefined', typeof obj._jdel);
+  return obj;
+}
+
+function assertNumberEquals(expected, actual) {
+  Assert.assertEquals(expected, actual, 0)
+}
+
+function assertFloatEquals(expected, actual) {
+  Assert["assertEquals(float, float, float)"](expected, actual, 0)
+}
+
+function assertDoubleEquals(expected, actual) {
+  Assert["assertEquals(double, double, double)"](expected, actual, 0)
+}
+
+function setter(values, index) {
+  return function(val) {
+    values[index] = val;
+  };
+}
+
+function asyncResultSetter(values, index) {
+  return function(val, err) {
+    Assert.assertNull(err);
+    values[index] = val;
+  };
+}
+
+function testMethodWithBasicParameterizedReturn() {
+  checkMethodWithBasicParameterized([
+    obj.methodWithByteParameterizedReturn(),
+    obj.methodWithShortParameterizedReturn(),
+    obj.methodWithIntegerParameterizedReturn(),
+    obj.methodWithLongParameterizedReturn(),
+    obj.methodWithFloatParameterizedReturn(),
+    obj.methodWithDoubleParameterizedReturn(),
+    obj.methodWithBooleanParameterizedReturn(),
+    obj.methodWithCharacterParameterizedReturn(),
+    obj.methodWithStringParameterizedReturn()
+  ]);
+}
+
+function testMethodWithHandlerBasicParameterized() {
+  var values = [];
+  obj.methodWithHandlerByteParameterized(setter(values, 0));
+  obj.methodWithHandlerShortParameterized(setter(values, 1));
+  obj.methodWithHandlerIntegerParameterized(setter(values, 2));
+  obj.methodWithHandlerLongParameterized(setter(values, 3));
+  obj.methodWithHandlerFloatParameterized(setter(values, 4));
+  obj.methodWithHandlerDoubleParameterized(setter(values, 5));
+  obj.methodWithHandlerBooleanParameterized(setter(values, 6));
+  obj.methodWithHandlerCharacterParameterized(setter(values, 7));
+  obj.methodWithHandlerStringParameterized(setter(values, 8));
+  checkMethodWithBasicParameterized(values);
+}
+
+function testMethodWithHandlerAsyncResultBasicParameterized() {
+  var values = [];
+  obj.methodWithHandlerAsyncResultByteParameterized(asyncResultSetter(values, 0));
+  obj.methodWithHandlerAsyncResultShortParameterized(asyncResultSetter(values, 1));
+  obj.methodWithHandlerAsyncResultIntegerParameterized(asyncResultSetter(values, 2));
+  obj.methodWithHandlerAsyncResultLongParameterized(asyncResultSetter(values, 3));
+  obj.methodWithHandlerAsyncResultFloatParameterized(asyncResultSetter(values, 4));
+  obj.methodWithHandlerAsyncResultDoubleParameterized(asyncResultSetter(values, 5));
+  obj.methodWithHandlerAsyncResultBooleanParameterized(asyncResultSetter(values, 6));
+  obj.methodWithHandlerAsyncResultCharacterParameterized(asyncResultSetter(values, 7));
+  obj.methodWithHandlerAsyncResultStringParameterized(asyncResultSetter(values, 8));
+  checkMethodWithBasicParameterized(values);
+}
+
+function checkMethodWithBasicParameterized(values) {
+  var ret = assertApiType(values[0]);
+  assertNumberEquals(ret.getValue(), 123);
+  ret.setValue(124);
+  assertNumberEquals(ret.getValue(), 124);
+  ret = assertApiType(values[1]);
+  assertNumberEquals(ret.getValue(), 1234);
+  ret.setValue(1235);
+  assertNumberEquals(ret.getValue(), 1235);
+  ret = assertApiType(values[2]);
+  assertNumberEquals(ret.getValue(), 123456);
+  ret.setValue(1234568);
+  assertNumberEquals(ret.getValue(), 1234568);
+  ret = assertApiType(values[3]);
+  assertNumberEquals(ret.getValue(), 123456789);
+  ret.setValue(123456790);
+  assertNumberEquals(ret.getValue(), 123456790);
+  ret = assertApiType(values[4]);
+  assertFloatEquals(ret.getValue(), 0.34);
+  ret.setValue(0.35);
+  assertFloatEquals(ret.getValue(), 0.35);
+  ret = assertApiType(values[5]);
+  assertDoubleEquals(ret.getValue(), 0.314);
+  ret.setValue(0.3141);
+  assertDoubleEquals(ret.getValue(), 0.3141);
+  ret = assertApiType(values[6]);
+  Assert.assertEquals(ret.getValue(), true);
+  ret.setValue(false);
+  Assert.assertEquals(ret.getValue(), false);
+  ret = assertApiType(values[7]);
+  Assert.assertEquals(ret.getValue() + "", "F");
+  ret.setValue("G");
+  Assert.assertEquals(ret.getValue() + "", "G");
+  ret = assertApiType(values[8]);
+  Assert.assertEquals(ret.getValue(), "zoumbawe");
+  ret.setValue("the_string");
+  Assert.assertEquals(ret.getValue(), "the_string");
+}
+
+function testMethodWithJsonParameterizedReturn() {
+  checkMethodWitJsonParameterized([
+    obj.methodWithJsonObjectParameterizedReturn(),
+    obj.methodWithJsonArrayParameterizedReturn()
+  ])
+}
+
+function testMethodWithHandlerJsonParameterized() {
+  var values = [];
+  obj.methodWithHandlerJsonObjectParameterized(setter(values, 0));
+  obj.methodWithHandlerJsonArrayParameterized(setter(values, 1));
+  checkMethodWitJsonParameterized(values);
+}
+
+function testMethodWithHandlerAsyncResultJsonParameterized() {
+  var values = [];
+  obj.methodWithHandlerAsyncResultJsonObjectParameterized(asyncResultSetter(values, 0));
+  obj.methodWithHandlerAsyncResultJsonArrayParameterized(asyncResultSetter(values, 1));
+  checkMethodWitJsonParameterized(values);
+}
+
+function checkMethodWitJsonParameterized(values) {
+  var ret = assertApiType(values[0]);
+  var val = ret.getValue();
+  Assert.assertTrue(typeof val === 'object');
+  Assert.assertEquals(val.cheese, "stilton");
+  ret.setValue({"cheese": "roquefort"});
+  val = ret.getValue();
+  Assert.assertTrue(typeof val === 'object');
+  Assert.assertEquals(val.cheese, "roquefort");
+  ret = assertApiType(values[1]);
+  val = ret.getValue();
+  Assert.assertTrue(val instanceof Array);
+  Assert.assertEquals(val[0], "cheese");
+  Assert.assertEquals(val[1], "stilton");
+  ret.setValue(["cheese", "roquefort"]);
+  val = ret.getValue();
+  Assert.assertTrue(val instanceof Array);
+  Assert.assertEquals(val[0], "cheese");
+  Assert.assertEquals(val[1], "roquefort");
+}
+
+function testMethodWithDataObjectParameterizedReturn() {
+  checkMethodWitDataObjectParameterized([obj.methodWithDataObjectParameterizedReturn()]);
+}
+
+function testMethodWithHandlerDataObjectParameterized() {
+  var values = [];
+  obj.methodWithHandlerDataObjectParameterized(setter(values, 0));
+  checkMethodWitDataObjectParameterized(values);
+}
+
+function testMethodWithHandlerAsyncResultDataObjectParameterized() {
+  var values = [];
+  obj.methodWithHandlerAsyncResultDataObjectParameterized(asyncResultSetter(values, 0));
+  checkMethodWitDataObjectParameterized(values);
+}
+
+function checkMethodWitDataObjectParameterized(values) {
+  var ret = values[0];
+  var val = ret.getValue();
+  Assert.assertTrue(typeof val === 'object');
+  assertDoubleEquals(val.wibble, 3.14);
+  assertNumberEquals(val.bar, 123456);
+  Assert.assertEquals(val.foo, "foo_value");
+  ret.setValue({"wibble": 0.1, "bar": 543321, "foo": "another_value"});
+  val = ret.getValue();
+  Assert.assertTrue(typeof val === 'object');
+  assertDoubleEquals(val.wibble, 0.1);
+  assertNumberEquals(val.bar, 543321);
+  Assert.assertEquals(val.foo, "another_value");
+}
+
+function testMethodWithEnumParameterizedReturn() {
+  checkMethodWithEnumParameterized([
+    obj.methodWithEnumParameterizedReturn(),
+    obj.methodWithGenEnumParameterizedReturn()]);
+}
+
+function testMethodWithHandlerEnumParameterized() {
+  var values = [];
+  obj.methodWithHandlerEnumParameterized(setter(values, 0));
+  obj.methodWithHandlerGenEnumParameterized(setter(values, 1));
+  checkMethodWithEnumParameterized(values);
+}
+
+function testMethodWithHandlerAsyncResultEnumParameterized() {
+  var values = [];
+  obj.methodWithHandlerAsyncResultEnumParameterized(asyncResultSetter(values, 0));
+  obj.methodWithHandlerAsyncResultGenEnumParameterized(asyncResultSetter(values, 1));
+  checkMethodWithEnumParameterized(values);
+}
+
+function checkMethodWithEnumParameterized(values) {
+  var ret = assertApiType(values[0]);
+  Assert.assertEquals(ret.getValue(), "WESTON");
+  ret.setValue("JULIEN");
+  Assert.assertEquals(ret.getValue(), "JULIEN");
+  ret = assertApiType(values[1]);
+  Assert.assertEquals(ret.getValue(), "LELAND");
+  ret.setValue("LAURA");
+  Assert.assertEquals(ret.getValue(), "LAURA");
+}
+
 function testMethodWithUserTypeParameterizedReturn() {
-  var ret = obj.methodWithUserTypeParameterizedReturn();
+  checkMethodWithUserTypeParameterized([obj.methodWithUserTypeParameterizedReturn()])
+}
+
+function testMethodWithHandlerUserTypeParameterized() {
+  var values = [];
+  obj.methodWithHandlerUserTypeParameterized(setter(values, 0));
+  checkMethodWithUserTypeParameterized(values)
+}
+
+function testMethodWithHandlerAsyncResultUserTypeParameterized() {
+  var values = [];
+  obj.methodWithHandlerAsyncResultUserTypeParameterized(setter(values, 0));
+  checkMethodWithUserTypeParameterized(values)
+}
+
+function checkMethodWithUserTypeParameterized(values) {
+  var ret = values[0];
   Assert.assertNotEquals('undefined', typeof ret._jdel);
   var val = ret.getValue();
   Assert.assertNotEquals('undefined', typeof val._jdel);
   Assert.assertEquals('foo', val.getString());
 
-  refed_obj.setString("the_string")
+  refed_obj.setString("the_string");
   ret.setValue(refed_obj);
   val = ret.getValue();
   Assert.assertNotEquals('undefined', typeof val._jdel);
@@ -22,19 +253,55 @@ function testMethodWithUserTypeParameterizedReturn() {
 }
 
 function testMethodWithClassTypeParameterizedReturn() {
-  var ret = obj.methodWithClassTypeParameterizedReturn(RefedInterface1);
+  checkMethodWithClassTypeParameterized([
+    obj.methodWithClassTypeParameterizedReturn(Number),
+    obj.methodWithClassTypeParameterizedReturn(Boolean),
+    obj.methodWithClassTypeParameterizedReturn(String),
+    obj.methodWithClassTypeParameterizedReturn(Object),
+    obj.methodWithClassTypeParameterizedReturn(Array),
+    obj.methodWithClassTypeParameterizedReturn(RefedInterface1)
+  ]);
+}
+
+function testMethodWithHandlerClassTypeParameterized() {
+  var values = [];
+  obj.methodWithHandlerClassTypeParameterized(Number, setter(values, 0));
+  obj.methodWithHandlerClassTypeParameterized(Boolean, setter(values, 1));
+  obj.methodWithHandlerClassTypeParameterized(String, setter(values, 2));
+  obj.methodWithHandlerClassTypeParameterized(Object, setter(values, 3));
+  obj.methodWithHandlerClassTypeParameterized(Array, setter(values, 4));
+  obj.methodWithHandlerClassTypeParameterized(RefedInterface1, setter(values, 5));
+  checkMethodWithClassTypeParameterized(values);
+}
+
+function testMethodWithHandlerAsyncResultClassTypeParameterized() {
+  var values = [];
+  obj.methodWithHandlerAsyncResultClassTypeParameterized(Number, asyncResultSetter(values, 0));
+  obj.methodWithHandlerAsyncResultClassTypeParameterized(Boolean, asyncResultSetter(values, 1));
+  obj.methodWithHandlerAsyncResultClassTypeParameterized(String, asyncResultSetter(values, 2));
+  obj.methodWithHandlerAsyncResultClassTypeParameterized(Object, asyncResultSetter(values, 3));
+  obj.methodWithHandlerAsyncResultClassTypeParameterized(Array, asyncResultSetter(values, 4));
+  obj.methodWithHandlerAsyncResultClassTypeParameterized(RefedInterface1, asyncResultSetter(values, 5));
+  checkMethodWithClassTypeParameterized(values);
+}
+
+function checkMethodWithClassTypeParameterized(values) {
+  var ret = values[0];
   Assert.assertNotEquals('undefined', typeof ret._jdel);
   var val = ret.getValue();
-  Assert.assertNotEquals('undefined', typeof val._jdel);
-  Assert.assertEquals('foo', val.getString());
+  assertNumberEquals(val, 123456789);
 
-  refed_obj.setString("the_string")
-  ret.setValue(refed_obj);
+  ret = values[1];
+  Assert.assertNotEquals('undefined', typeof ret._jdel);
   val = ret.getValue();
-  Assert.assertNotEquals('undefined', typeof val._jdel);
-  Assert.assertEquals('the_string', val.getString());
+  Assert.assertEquals(val, true);
 
-  ret = obj.methodWithClassTypeParameterizedReturn(Object);
+  ret = values[2];
+  Assert.assertNotEquals('undefined', typeof ret._jdel);
+  val = ret.getValue();
+  Assert.assertEquals(val, "zoumbawe");
+
+  ret = values[3];
   Assert.assertNotEquals('undefined', typeof ret._jdel);
   val = ret.getValue();
   Assert.assertEquals("stilton", val["cheese"]);
@@ -42,26 +309,28 @@ function testMethodWithClassTypeParameterizedReturn() {
   ret.setValue({"wine":"condrieu"});
   val = ret.getValue();
   Assert.assertEquals("condrieu", val["wine"]);
-}
 
-function testMethodWithHandlerClassTypeParameterized() {
-  var count = 0;
-  obj.methodWithHandlerClassTypeParameterized(RefedInterface1, function(ret) {
-    Assert.assertNotEquals('undefined', typeof ret._jdel);
-    var val = ret.getValue();
-    Assert.assertNotEquals('undefined', typeof val._jdel);
-    Assert.assertEquals('foo', val.getString());
-    count++;
-  });
-  Assert.assertEquals(1, count, 0);
+  ret = values[4];
+  Assert.assertNotEquals('undefined', typeof ret._jdel);
+  val = ret.getValue();
+  Assert.assertEquals("cheese", val[0]);
+  Assert.assertEquals("stilton", val[1]);
 
-  ret = obj.methodWithHandlerClassTypeParameterized(Object, function(ret) {
-    Assert.assertNotEquals('undefined', typeof ret._jdel);
-    var val = ret.getValue();
-    Assert.assertEquals("stilton", val["cheese"]);
-    count++;
-  });
-  Assert.assertEquals(2, count, 0);
+  ret.setValue({"wine":"condrieu"});
+  val = ret.getValue();
+  Assert.assertEquals("condrieu", val["wine"]);
+
+  ret = values[5];
+  Assert.assertNotEquals('undefined', typeof ret._jdel);
+  val = ret.getValue();
+  Assert.assertNotEquals('undefined', typeof val._jdel);
+  Assert.assertEquals('foo', val.getString());
+
+  refed_obj.setString("the_string");
+  ret.setValue(refed_obj);
+  val = ret.getValue();
+  Assert.assertNotEquals('undefined', typeof val._jdel);
+  Assert.assertEquals('the_string', val.getString());
 }
 
 function testInterfaceWithStringArg() {
@@ -80,9 +349,9 @@ function testInterfaceWithVariableArg() {
   Assert.assertNotEquals('undefined', typeof val._jdel);
   Assert.assertEquals('the_string_value', val.getString());
 
-  var ret = obj.interfaceWithVariableArg('whatever', String, 'the_string_arg');
+  ret = obj.interfaceWithVariableArg('whatever', String, 'the_string_arg');
   Assert.assertNotEquals('undefined', typeof ret._jdel);
-  var val = ret.getValue();
+  val = ret.getValue();
   Assert.assertEquals('undefined', typeof val._jdel);
   Assert.assertEquals('the_string_arg', val);
 }

--- a/src/test/resources/generics_tck_test.js
+++ b/src/test/resources/generics_tck_test.js
@@ -1,0 +1,61 @@
+var Assert = org.junit.Assert;
+
+var GenericsTCK = require('testmodel-js/generics_tck');
+var RefedInterface1 = require('testmodel-js/refed_interface1');
+
+var obj = new GenericsTCK(new Packages.io.vertx.codegen.testmodel.GenericsTCKImpl());
+var refed_obj = new RefedInterface1(new Packages.io.vertx.codegen.testmodel.RefedInterface1Impl());
+var refed_obj2 = new RefedInterface1(new Packages.io.vertx.codegen.testmodel.RefedInterface1Impl());
+
+function testMethodWithUserTypeParameterizedReturn() {
+  var ret = obj.methodWithUserTypeParameterizedReturn();
+  Assert.assertNotEquals('undefined', typeof ret._jdel);
+  var val = ret.getValue();
+  Assert.assertNotEquals('undefined', typeof val._jdel);
+  Assert.assertEquals('foo', val.getString());
+}
+
+function testMethodWithClassTypeParameterizedReturn() {
+  var ret = obj.methodWithClassTypeParameterizedReturn(RefedInterface1);
+  Assert.assertNotEquals('undefined', typeof ret._jdel);
+  var val = ret.getValue();
+  Assert.assertNotEquals('undefined', typeof val._jdel);
+  Assert.assertEquals('foo', val.getString());
+
+  ret = obj.methodWithClassTypeParameterizedReturn(Object);
+  Assert.assertNotEquals('undefined', typeof ret._jdel);
+  val = ret.getValue();
+  Assert.assertEquals("stilton", val["cheese"]);
+}
+
+function testMethodWithHandlerClassTypeParameterized() {
+  var count = 0;
+  obj.methodWithHandlerClassTypeParameterized(RefedInterface1, function(ret) {
+    Assert.assertNotEquals('undefined', typeof ret._jdel);
+    var val = ret.getValue();
+    Assert.assertNotEquals('undefined', typeof val._jdel);
+    Assert.assertEquals('foo', val.getString());
+    count++;
+  });
+  Assert.assertEquals(1, count, 0);
+
+  ret = obj.methodWithHandlerClassTypeParameterized(Object, function(ret) {
+    Assert.assertNotEquals('undefined', typeof ret._jdel);
+    var val = ret.getValue();
+    Assert.assertEquals("stilton", val["cheese"]);
+    count++;
+  });
+  Assert.assertEquals(2, count, 0);
+}
+
+if (typeof this[testName] === 'undefined') {
+  throw "No such test: " + testName;
+}
+
+this[testName]();
+
+
+
+
+
+

--- a/src/test/resources/testmodel-js/abstract_handler_user_type.js
+++ b/src/test/resources/testmodel-js/abstract_handler_user_type.js
@@ -49,5 +49,12 @@ var AbstractHandlerUserType = function(j_val) {
   this._jdel = j_abstractHandlerUserType;
 };
 
+AbstractHandlerUserType._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.AbstractHandlerUserType");
+AbstractHandlerUserType._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(AbstractHandlerUserType.prototype, {});
+  AbstractHandlerUserType.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = AbstractHandlerUserType;

--- a/src/test/resources/testmodel-js/abstract_handler_user_type.js
+++ b/src/test/resources/testmodel-js/abstract_handler_user_type.js
@@ -50,6 +50,20 @@ var AbstractHandlerUserType = function(j_val) {
 };
 
 AbstractHandlerUserType._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.AbstractHandlerUserType");
+AbstractHandlerUserType._jtype = {
+  accept: function(obj) {
+    return AbstractHandlerUserType._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(AbstractHandlerUserType.prototype, {});
+    AbstractHandlerUserType.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 AbstractHandlerUserType._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(AbstractHandlerUserType.prototype, {});

--- a/src/test/resources/testmodel-js/abstract_handler_user_type.js
+++ b/src/test/resources/testmodel-js/abstract_handler_user_type.js
@@ -55,7 +55,6 @@ AbstractHandlerUserType._jtype = {
     return AbstractHandlerUserType._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(AbstractHandlerUserType.prototype, {});
     AbstractHandlerUserType.apply(obj, arguments);
     return obj;
@@ -65,10 +64,8 @@ AbstractHandlerUserType._jtype = {
   }
 };
 AbstractHandlerUserType._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(AbstractHandlerUserType.prototype, {});
   AbstractHandlerUserType.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = AbstractHandlerUserType;

--- a/src/test/resources/testmodel-js/collection_tck.js
+++ b/src/test/resources/testmodel-js/collection_tck.js
@@ -1151,5 +1151,12 @@ var CollectionTCK = function(j_val) {
   this._jdel = j_collectionTCK;
 };
 
+CollectionTCK._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.CollectionTCK");
+CollectionTCK._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(CollectionTCK.prototype, {});
+  CollectionTCK.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = CollectionTCK;

--- a/src/test/resources/testmodel-js/collection_tck.js
+++ b/src/test/resources/testmodel-js/collection_tck.js
@@ -1152,6 +1152,20 @@ var CollectionTCK = function(j_val) {
 };
 
 CollectionTCK._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.CollectionTCK");
+CollectionTCK._jtype = {
+  accept: function(obj) {
+    return CollectionTCK._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(CollectionTCK.prototype, {});
+    CollectionTCK.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 CollectionTCK._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(CollectionTCK.prototype, {});

--- a/src/test/resources/testmodel-js/collection_tck.js
+++ b/src/test/resources/testmodel-js/collection_tck.js
@@ -1157,7 +1157,6 @@ CollectionTCK._jtype = {
     return CollectionTCK._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(CollectionTCK.prototype, {});
     CollectionTCK.apply(obj, arguments);
     return obj;
@@ -1167,10 +1166,8 @@ CollectionTCK._jtype = {
   }
 };
 CollectionTCK._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(CollectionTCK.prototype, {});
   CollectionTCK.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = CollectionTCK;

--- a/src/test/resources/testmodel-js/concrete_handler_user_type.js
+++ b/src/test/resources/testmodel-js/concrete_handler_user_type.js
@@ -49,5 +49,12 @@ var ConcreteHandlerUserType = function(j_val) {
   this._jdel = j_concreteHandlerUserType;
 };
 
+ConcreteHandlerUserType._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.ConcreteHandlerUserType");
+ConcreteHandlerUserType._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(ConcreteHandlerUserType.prototype, {});
+  ConcreteHandlerUserType.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = ConcreteHandlerUserType;

--- a/src/test/resources/testmodel-js/concrete_handler_user_type.js
+++ b/src/test/resources/testmodel-js/concrete_handler_user_type.js
@@ -55,7 +55,6 @@ ConcreteHandlerUserType._jtype = {
     return ConcreteHandlerUserType._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(ConcreteHandlerUserType.prototype, {});
     ConcreteHandlerUserType.apply(obj, arguments);
     return obj;
@@ -65,10 +64,8 @@ ConcreteHandlerUserType._jtype = {
   }
 };
 ConcreteHandlerUserType._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(ConcreteHandlerUserType.prototype, {});
   ConcreteHandlerUserType.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = ConcreteHandlerUserType;

--- a/src/test/resources/testmodel-js/concrete_handler_user_type.js
+++ b/src/test/resources/testmodel-js/concrete_handler_user_type.js
@@ -50,6 +50,20 @@ var ConcreteHandlerUserType = function(j_val) {
 };
 
 ConcreteHandlerUserType._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.ConcreteHandlerUserType");
+ConcreteHandlerUserType._jtype = {
+  accept: function(obj) {
+    return ConcreteHandlerUserType._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(ConcreteHandlerUserType.prototype, {});
+    ConcreteHandlerUserType.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 ConcreteHandlerUserType._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(ConcreteHandlerUserType.prototype, {});

--- a/src/test/resources/testmodel-js/concrete_handler_user_type_extension.js
+++ b/src/test/resources/testmodel-js/concrete_handler_user_type_extension.js
@@ -52,6 +52,20 @@ var ConcreteHandlerUserTypeExtension = function(j_val) {
 };
 
 ConcreteHandlerUserTypeExtension._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.ConcreteHandlerUserTypeExtension");
+ConcreteHandlerUserTypeExtension._jtype = {
+  accept: function(obj) {
+    return ConcreteHandlerUserTypeExtension._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(ConcreteHandlerUserTypeExtension.prototype, {});
+    ConcreteHandlerUserTypeExtension.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 ConcreteHandlerUserTypeExtension._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(ConcreteHandlerUserTypeExtension.prototype, {});

--- a/src/test/resources/testmodel-js/concrete_handler_user_type_extension.js
+++ b/src/test/resources/testmodel-js/concrete_handler_user_type_extension.js
@@ -57,7 +57,6 @@ ConcreteHandlerUserTypeExtension._jtype = {
     return ConcreteHandlerUserTypeExtension._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(ConcreteHandlerUserTypeExtension.prototype, {});
     ConcreteHandlerUserTypeExtension.apply(obj, arguments);
     return obj;
@@ -67,10 +66,8 @@ ConcreteHandlerUserTypeExtension._jtype = {
   }
 };
 ConcreteHandlerUserTypeExtension._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(ConcreteHandlerUserTypeExtension.prototype, {});
   ConcreteHandlerUserTypeExtension.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = ConcreteHandlerUserTypeExtension;

--- a/src/test/resources/testmodel-js/concrete_handler_user_type_extension.js
+++ b/src/test/resources/testmodel-js/concrete_handler_user_type_extension.js
@@ -51,5 +51,12 @@ var ConcreteHandlerUserTypeExtension = function(j_val) {
   this._jdel = j_concreteHandlerUserTypeExtension;
 };
 
+ConcreteHandlerUserTypeExtension._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.ConcreteHandlerUserTypeExtension");
+ConcreteHandlerUserTypeExtension._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(ConcreteHandlerUserTypeExtension.prototype, {});
+  ConcreteHandlerUserTypeExtension.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = ConcreteHandlerUserTypeExtension;

--- a/src/test/resources/testmodel-js/data_object_tck.js
+++ b/src/test/resources/testmodel-js/data_object_tck.js
@@ -143,6 +143,20 @@ var DataObjectTCK = function(j_val) {
 };
 
 DataObjectTCK._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.DataObjectTCK");
+DataObjectTCK._jtype = {
+  accept: function(obj) {
+    return DataObjectTCK._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(DataObjectTCK.prototype, {});
+    DataObjectTCK.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 DataObjectTCK._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(DataObjectTCK.prototype, {});

--- a/src/test/resources/testmodel-js/data_object_tck.js
+++ b/src/test/resources/testmodel-js/data_object_tck.js
@@ -148,7 +148,6 @@ DataObjectTCK._jtype = {
     return DataObjectTCK._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(DataObjectTCK.prototype, {});
     DataObjectTCK.apply(obj, arguments);
     return obj;
@@ -158,10 +157,8 @@ DataObjectTCK._jtype = {
   }
 };
 DataObjectTCK._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(DataObjectTCK.prototype, {});
   DataObjectTCK.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = DataObjectTCK;

--- a/src/test/resources/testmodel-js/data_object_tck.js
+++ b/src/test/resources/testmodel-js/data_object_tck.js
@@ -142,5 +142,12 @@ var DataObjectTCK = function(j_val) {
   this._jdel = j_dataObjectTCK;
 };
 
+DataObjectTCK._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.DataObjectTCK");
+DataObjectTCK._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(DataObjectTCK.prototype, {});
+  DataObjectTCK.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = DataObjectTCK;

--- a/src/test/resources/testmodel-js/factory.js
+++ b/src/test/resources/testmodel-js/factory.js
@@ -46,7 +46,6 @@ Factory._jtype = {
     return Factory._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(Factory.prototype, {});
     Factory.apply(obj, arguments);
     return obj;
@@ -56,7 +55,6 @@ Factory._jtype = {
   }
 };
 Factory._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(Factory.prototype, {});
   Factory.apply(obj, arguments);
   return obj;
@@ -106,5 +104,4 @@ Factory.createConcreteHandlerUserTypeExtension = function(handler) {
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
-// We export the Constructor function
 module.exports = Factory;

--- a/src/test/resources/testmodel-js/factory.js
+++ b/src/test/resources/testmodel-js/factory.js
@@ -40,6 +40,13 @@ var Factory = function(j_val) {
   this._jdel = j_factory;
 };
 
+Factory._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.Factory");
+Factory._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(Factory.prototype, {});
+  Factory.apply(obj, arguments);
+  return obj;
+}
 /**
 
  @memberof module:testmodel-js/factory
@@ -49,9 +56,9 @@ var Factory = function(j_val) {
 Factory.createConcreteHandlerUserType = function(handler) {
   var __args = arguments;
   if (__args.length === 1 && typeof __args[0] === 'function') {
-    return utils.convReturnVertxGen(JFactory["createConcreteHandlerUserType(io.vertx.core.Handler)"](function(jVal) {
-    handler(utils.convReturnVertxGen(jVal, RefedInterface1));
-  }), ConcreteHandlerUserType);
+    return utils.convReturnVertxGen(ConcreteHandlerUserType, JFactory["createConcreteHandlerUserType(io.vertx.core.Handler)"](function(jVal) {
+    handler(utils.convReturnVertxGen(RefedInterface1, jVal));
+  }));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -64,9 +71,9 @@ Factory.createConcreteHandlerUserType = function(handler) {
 Factory.createAbstractHandlerUserType = function(handler) {
   var __args = arguments;
   if (__args.length === 1 && typeof __args[0] === 'function') {
-    return utils.convReturnVertxGen(JFactory["createAbstractHandlerUserType(io.vertx.core.Handler)"](function(jVal) {
-    handler(utils.convReturnVertxGen(jVal, RefedInterface1));
-  }), AbstractHandlerUserType);
+    return utils.convReturnVertxGen(AbstractHandlerUserType, JFactory["createAbstractHandlerUserType(io.vertx.core.Handler)"](function(jVal) {
+    handler(utils.convReturnVertxGen(RefedInterface1, jVal));
+  }));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -79,9 +86,9 @@ Factory.createAbstractHandlerUserType = function(handler) {
 Factory.createConcreteHandlerUserTypeExtension = function(handler) {
   var __args = arguments;
   if (__args.length === 1 && typeof __args[0] === 'function') {
-    return utils.convReturnVertxGen(JFactory["createConcreteHandlerUserTypeExtension(io.vertx.core.Handler)"](function(jVal) {
-    handler(utils.convReturnVertxGen(jVal, RefedInterface1));
-  }), ConcreteHandlerUserTypeExtension);
+    return utils.convReturnVertxGen(ConcreteHandlerUserTypeExtension, JFactory["createConcreteHandlerUserTypeExtension(io.vertx.core.Handler)"](function(jVal) {
+    handler(utils.convReturnVertxGen(RefedInterface1, jVal));
+  }));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 

--- a/src/test/resources/testmodel-js/factory.js
+++ b/src/test/resources/testmodel-js/factory.js
@@ -41,6 +41,20 @@ var Factory = function(j_val) {
 };
 
 Factory._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.Factory");
+Factory._jtype = {
+  accept: function(obj) {
+    return Factory._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(Factory.prototype, {});
+    Factory.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 Factory._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(Factory.prototype, {});

--- a/src/test/resources/testmodel-js/function_param_tck.js
+++ b/src/test/resources/testmodel-js/function_param_tck.js
@@ -502,7 +502,6 @@ FunctionParamTCK._jtype = {
     return FunctionParamTCK._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(FunctionParamTCK.prototype, {});
     FunctionParamTCK.apply(obj, arguments);
     return obj;
@@ -512,10 +511,8 @@ FunctionParamTCK._jtype = {
   }
 };
 FunctionParamTCK._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(FunctionParamTCK.prototype, {});
   FunctionParamTCK.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = FunctionParamTCK;

--- a/src/test/resources/testmodel-js/function_param_tck.js
+++ b/src/test/resources/testmodel-js/function_param_tck.js
@@ -497,6 +497,20 @@ var FunctionParamTCK = function(j_val) {
 };
 
 FunctionParamTCK._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.FunctionParamTCK");
+FunctionParamTCK._jtype = {
+  accept: function(obj) {
+    return FunctionParamTCK._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(FunctionParamTCK.prototype, {});
+    FunctionParamTCK.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 FunctionParamTCK._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(FunctionParamTCK.prototype, {});

--- a/src/test/resources/testmodel-js/function_param_tck.js
+++ b/src/test/resources/testmodel-js/function_param_tck.js
@@ -125,7 +125,7 @@ var FunctionParamTCK = function(j_val) {
     var __args = arguments;
     if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'function') {
       return j_functionParamTCK["methodWithUserTypeParam(io.vertx.codegen.testmodel.RefedInterface1,java.util.function.Function)"](arg._jdel, function(jVal) {
-      var jRet = func(utils.convReturnVertxGen(jVal, RefedInterface1));
+      var jRet = func(utils.convReturnVertxGen(RefedInterface1, jVal));
       return jRet;
     });
     } else throw new TypeError('function invoked with invalid arguments');
@@ -256,7 +256,7 @@ var FunctionParamTCK = function(j_val) {
     var __args = arguments;
     if (__args.length === 2 && typeof __args[0] !== 'function' && typeof __args[1] === 'function') {
       return j_functionParamTCK["methodWithGenericUserTypeParam(java.lang.Object,java.util.function.Function)"](utils.convParamTypeUnknown(t), function(jVal) {
-      var jRet = func(utils.convReturnVertxGen(jVal, GenericRefedInterface));
+      var jRet = func(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
       return jRet;
     });
     } else throw new TypeError('function invoked with invalid arguments');
@@ -452,7 +452,7 @@ var FunctionParamTCK = function(j_val) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'function') {
       return j_functionParamTCK["methodWithGenericUserTypeReturn(java.util.function.Function)"](function(jVal) {
-      var jRet = func(utils.convReturnVertxGen(jVal, GenericRefedInterface));
+      var jRet = func(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
       return jRet._jdel;
     });
     } else throw new TypeError('function invoked with invalid arguments');
@@ -496,5 +496,12 @@ var FunctionParamTCK = function(j_val) {
   this._jdel = j_functionParamTCK;
 };
 
+FunctionParamTCK._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.FunctionParamTCK");
+FunctionParamTCK._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(FunctionParamTCK.prototype, {});
+  FunctionParamTCK.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = FunctionParamTCK;

--- a/src/test/resources/testmodel-js/generic_refed_interface.js
+++ b/src/test/resources/testmodel-js/generic_refed_interface.js
@@ -25,10 +25,11 @@ var JGenericRefedInterface = io.vertx.codegen.testmodel.GenericRefedInterface;
 
  @class
 */
-var GenericRefedInterface = function(j_val) {
+var GenericRefedInterface = function(j_val, j_arg_0) {
 
   var j_genericRefedInterface = j_val;
   var that = this;
+  var j_T = typeof j_arg_0 === 'function' ? j_arg_0 : utils.convReturnTypeUnknown;
 
   /**
 
@@ -51,7 +52,7 @@ var GenericRefedInterface = function(j_val) {
   this.getValue = function() {
     var __args = arguments;
     if (__args.length === 0) {
-      return utils.convReturnTypeUnknown(j_genericRefedInterface["getValue()"]());
+      return j_T(j_genericRefedInterface["getValue()"]());
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -61,5 +62,12 @@ var GenericRefedInterface = function(j_val) {
   this._jdel = j_genericRefedInterface;
 };
 
+GenericRefedInterface._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.GenericRefedInterface");
+GenericRefedInterface._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(GenericRefedInterface.prototype, {});
+  GenericRefedInterface.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = GenericRefedInterface;

--- a/src/test/resources/testmodel-js/generic_refed_interface.js
+++ b/src/test/resources/testmodel-js/generic_refed_interface.js
@@ -70,7 +70,6 @@ GenericRefedInterface._jtype = {
     return GenericRefedInterface._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(GenericRefedInterface.prototype, {});
     GenericRefedInterface.apply(obj, arguments);
     return obj;
@@ -80,10 +79,8 @@ GenericRefedInterface._jtype = {
   }
 };
 GenericRefedInterface._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(GenericRefedInterface.prototype, {});
   GenericRefedInterface.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = GenericRefedInterface;

--- a/src/test/resources/testmodel-js/generic_refed_interface.js
+++ b/src/test/resources/testmodel-js/generic_refed_interface.js
@@ -29,7 +29,7 @@ var GenericRefedInterface = function(j_val, j_arg_0) {
 
   var j_genericRefedInterface = j_val;
   var that = this;
-  var j_T = typeof j_arg_0 === 'function' ? j_arg_0 : utils.convReturnTypeUnknown;
+  var j_T = typeof j_arg_0 !== 'undefined' ? j_arg_0 : utils.unknown_jtype;
 
   /**
 
@@ -38,8 +38,8 @@ var GenericRefedInterface = function(j_val, j_arg_0) {
    */
   this.setValue = function(value) {
     var __args = arguments;
-    if (__args.length === 1 && typeof __args[0] !== 'function') {
-      j_genericRefedInterface["setValue(java.lang.Object)"](utils.convParamTypeUnknown(value));
+    if (__args.length === 1 && j_T.accept(__args[0])) {
+      j_genericRefedInterface["setValue(java.lang.Object)"](j_T.unwrap(value));
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -52,7 +52,7 @@ var GenericRefedInterface = function(j_val, j_arg_0) {
   this.getValue = function() {
     var __args = arguments;
     if (__args.length === 0) {
-      return j_T(j_genericRefedInterface["getValue()"]());
+      return j_T.wrap(j_genericRefedInterface["getValue()"]());
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -63,6 +63,20 @@ var GenericRefedInterface = function(j_val, j_arg_0) {
 };
 
 GenericRefedInterface._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.GenericRefedInterface");
+GenericRefedInterface._jtype = {
+  accept: function(obj) {
+    return GenericRefedInterface._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(GenericRefedInterface.prototype, {});
+    GenericRefedInterface.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 GenericRefedInterface._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(GenericRefedInterface.prototype, {});

--- a/src/test/resources/testmodel-js/generic_refed_interface.js
+++ b/src/test/resources/testmodel-js/generic_refed_interface.js
@@ -35,11 +35,13 @@ var GenericRefedInterface = function(j_val, j_arg_0) {
 
    @public
    @param value {Object} 
+   @return {GenericRefedInterface}
    */
   this.setValue = function(value) {
     var __args = arguments;
     if (__args.length === 1 && j_T.accept(__args[0])) {
       j_genericRefedInterface["setValue(java.lang.Object)"](j_T.unwrap(value));
+      return that;
     } else throw new TypeError('function invoked with invalid arguments');
   };
 

--- a/src/test/resources/testmodel-js/generics_tck.js
+++ b/src/test/resources/testmodel-js/generics_tck.js
@@ -201,7 +201,7 @@ var GenericsTCK = function(j_val) {
   this.methodWithEnumParameterizedReturn = function() {
     var __args = arguments;
     if (__args.length === 0) {
-      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithEnumParameterizedReturn()"](), undefined);
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithEnumParameterizedReturn()"](), utils.enum_jtype(io.vertx.codegen.testmodel.TestEnum));
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -214,7 +214,7 @@ var GenericsTCK = function(j_val) {
   this.methodWithGenEnumParameterizedReturn = function() {
     var __args = arguments;
     if (__args.length === 0) {
-      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithGenEnumParameterizedReturn()"](), undefined);
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithGenEnumParameterizedReturn()"](), utils.enum_jtype(io.vertx.codegen.testmodel.TestGenEnum));
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -408,7 +408,7 @@ var GenericsTCK = function(j_val) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_genericsTCK["methodWithHandlerEnumParameterized(io.vertx.core.Handler)"](function(jVal) {
-      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, utils.enum_jtype(io.vertx.codegen.testmodel.TestEnum)));
     });
     } else throw new TypeError('function invoked with invalid arguments');
   };
@@ -422,7 +422,7 @@ var GenericsTCK = function(j_val) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_genericsTCK["methodWithHandlerGenEnumParameterized(io.vertx.core.Handler)"](function(jVal) {
-      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, utils.enum_jtype(io.vertx.codegen.testmodel.TestGenEnum)));
     });
     } else throw new TypeError('function invoked with invalid arguments');
   };
@@ -667,7 +667,7 @@ var GenericsTCK = function(j_val) {
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_genericsTCK["methodWithHandlerAsyncResultEnumParameterized(io.vertx.core.Handler)"](function(ar) {
       if (ar.succeeded()) {
-        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), utils.enum_jtype(io.vertx.codegen.testmodel.TestEnum)), null);
       } else {
         handler(null, ar.cause());
       }
@@ -685,7 +685,7 @@ var GenericsTCK = function(j_val) {
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_genericsTCK["methodWithHandlerAsyncResultGenEnumParameterized(io.vertx.core.Handler)"](function(ar) {
       if (ar.succeeded()) {
-        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), utils.enum_jtype(io.vertx.codegen.testmodel.TestGenEnum)), null);
       } else {
         handler(null, ar.cause());
       }

--- a/src/test/resources/testmodel-js/generics_tck.js
+++ b/src/test/resources/testmodel-js/generics_tck.js
@@ -17,6 +17,9 @@
 /** @module testmodel-js/generics_tck */
 var utils = require('vertx-js/util/utils');
 var GenericRefedInterface = require('testmodel-js/generic_refed_interface');
+var InterfaceWithApiArg = require('testmodel-js/interface_with_api_arg');
+var InterfaceWithVariableArg = require('testmodel-js/interface_with_variable_arg');
+var InterfaceWithStringArg = require('testmodel-js/interface_with_string_arg');
 var RefedInterface1 = require('testmodel-js/refed_interface1');
 
 var io = Packages.io;
@@ -224,7 +227,7 @@ var GenericsTCK = function(j_val) {
   this.methodWithUserTypeParameterizedReturn = function() {
     var __args = arguments;
     if (__args.length === 0) {
-      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithUserTypeParameterizedReturn()"](), RefedInterface1._create);
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithUserTypeParameterizedReturn()"](), RefedInterface1._jtype);
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -433,7 +436,7 @@ var GenericsTCK = function(j_val) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_genericsTCK["methodWithHandlerUserTypeParameterized(io.vertx.core.Handler)"](function(jVal) {
-      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, RefedInterface1._create));
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, RefedInterface1._jtype));
     });
     } else throw new TypeError('function invoked with invalid arguments');
   };
@@ -700,7 +703,7 @@ var GenericsTCK = function(j_val) {
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_genericsTCK["methodWithHandlerAsyncResultUserTypeParameterized(io.vertx.core.Handler)"](function(ar) {
       if (ar.succeeded()) {
-        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), RefedInterface1._create), null);
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), RefedInterface1._jtype), null);
       } else {
         handler(null, ar.cause());
       }
@@ -717,7 +720,7 @@ var GenericsTCK = function(j_val) {
   this.methodWithClassTypeParameterizedReturn = function(type) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'function') {
-      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithClassTypeParameterizedReturn(java.lang.Class)"](utils.javaTypeOf(type)), __args[0]._create);
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithClassTypeParameterizedReturn(java.lang.Class)"](utils.get_jclass(type)), utils.get_jtype(type));
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -730,8 +733,8 @@ var GenericsTCK = function(j_val) {
   this.methodWithHandlerClassTypeParameterized = function(type, handler) {
     var __args = arguments;
     if (__args.length === 2 && typeof __args[0] === 'function' && typeof __args[1] === 'function') {
-      j_genericsTCK["methodWithHandlerClassTypeParameterized(java.lang.Class,io.vertx.core.Handler)"](utils.javaTypeOf(type), function(jVal) {
-      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, __args[0]._create));
+      j_genericsTCK["methodWithHandlerClassTypeParameterized(java.lang.Class,io.vertx.core.Handler)"](utils.get_jclass(type), function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, utils.get_jtype(type)));
     });
     } else throw new TypeError('function invoked with invalid arguments');
   };
@@ -745,13 +748,54 @@ var GenericsTCK = function(j_val) {
   this.methodWithHandlerAsyncResultClassTypeParameterized = function(type, handler) {
     var __args = arguments;
     if (__args.length === 2 && typeof __args[0] === 'function' && typeof __args[1] === 'function') {
-      j_genericsTCK["methodWithHandlerAsyncResultClassTypeParameterized(java.lang.Class,io.vertx.core.Handler)"](utils.javaTypeOf(type), function(ar) {
+      j_genericsTCK["methodWithHandlerAsyncResultClassTypeParameterized(java.lang.Class,io.vertx.core.Handler)"](utils.get_jclass(type), function(ar) {
       if (ar.succeeded()) {
-        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), __args[0]._create), null);
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), utils.get_jtype(type)), null);
       } else {
         handler(null, ar.cause());
       }
     });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param value {RefedInterface1} 
+   @return {InterfaceWithApiArg}
+   */
+  this.interfaceWithApiArg = function(value) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'object' && __args[0]._jdel) {
+      return utils.convReturnVertxGen(InterfaceWithApiArg, j_genericsTCK["interfaceWithApiArg(io.vertx.codegen.testmodel.RefedInterface1)"](value._jdel));
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param value {string} 
+   @return {InterfaceWithStringArg}
+   */
+  this.interfaceWithStringArg = function(value) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'string') {
+      return utils.convReturnVertxGen(InterfaceWithStringArg, j_genericsTCK["interfaceWithStringArg(java.lang.String)"](value));
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param value1 {Object} 
+   @param type {todo} 
+   @param value2 {Object} 
+   @return {InterfaceWithVariableArg}
+   */
+  this.interfaceWithVariableArg = function(value1, type, value2) {
+    var __args = arguments;
+    if (__args.length === 3 && typeof __args[0] !== 'function' && typeof __args[1] === 'function' && typeof __args[2] !== 'function') {
+      return utils.convReturnVertxGen(InterfaceWithVariableArg, j_genericsTCK["interfaceWithVariableArg(java.lang.Object,java.lang.Class,java.lang.Object)"](utils.convParamTypeUnknown(value1), utils.get_jclass(type), utils.get_jtype(type).unwrap(value2)), undefined, utils.get_jtype(type));
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -762,6 +806,20 @@ var GenericsTCK = function(j_val) {
 };
 
 GenericsTCK._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.GenericsTCK");
+GenericsTCK._jtype = {
+  accept: function(obj) {
+    return GenericsTCK._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(GenericsTCK.prototype, {});
+    GenericsTCK.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 GenericsTCK._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(GenericsTCK.prototype, {});

--- a/src/test/resources/testmodel-js/generics_tck.js
+++ b/src/test/resources/testmodel-js/generics_tck.js
@@ -1144,7 +1144,6 @@ GenericsTCK._jtype = {
     return GenericsTCK._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(GenericsTCK.prototype, {});
     GenericsTCK.apply(obj, arguments);
     return obj;
@@ -1154,10 +1153,8 @@ GenericsTCK._jtype = {
   }
 };
 GenericsTCK._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(GenericsTCK.prototype, {});
   GenericsTCK.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = GenericsTCK;

--- a/src/test/resources/testmodel-js/generics_tck.js
+++ b/src/test/resources/testmodel-js/generics_tck.js
@@ -1,0 +1,772 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** @module testmodel-js/generics_tck */
+var utils = require('vertx-js/util/utils');
+var GenericRefedInterface = require('testmodel-js/generic_refed_interface');
+var RefedInterface1 = require('testmodel-js/refed_interface1');
+
+var io = Packages.io;
+var JsonObject = io.vertx.core.json.JsonObject;
+var JGenericsTCK = io.vertx.codegen.testmodel.GenericsTCK;
+var TestDataObject = io.vertx.codegen.testmodel.TestDataObject;
+
+/**
+
+ @class
+*/
+var GenericsTCK = function(j_val) {
+
+  var j_genericsTCK = j_val;
+  var that = this;
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithByteParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithByteParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithShortParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithShortParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithIntegerParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithIntegerParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithLongParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithLongParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithFloatParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithFloatParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithDoubleParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithDoubleParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithBooleanParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithBooleanParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithCharacterParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithCharacterParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithStringParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithStringParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithJsonObjectParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithJsonObjectParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithJsonArrayParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithJsonArrayParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithDataObjectParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithDataObjectParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithEnumParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithEnumParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithGenEnumParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithGenEnumParameterizedReturn()"](), undefined);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {GenericRefedInterface}
+   */
+  this.methodWithUserTypeParameterizedReturn = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithUserTypeParameterizedReturn()"](), RefedInterface1._create);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerByteParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerByteParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerShortParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerShortParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerIntegerParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerIntegerParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerLongParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerLongParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerFloatParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerFloatParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerDoubleParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerDoubleParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerBooleanParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerBooleanParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerCharacterParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerCharacterParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerStringParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerStringParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerJsonObjectParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerJsonObjectParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerJsonArrayParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerJsonArrayParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerDataObjectParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerDataObjectParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerEnumParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerEnumParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerGenEnumParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerGenEnumParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerUserTypeParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerUserTypeParameterized(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, RefedInterface1._create));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultByteParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultByteParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultShortParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultShortParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultIntegerParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultIntegerParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultLongParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultLongParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultFloatParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultFloatParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultDoubleParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultDoubleParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultBooleanParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultBooleanParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultCharacterParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultCharacterParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultStringParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultStringParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultJsonObjectParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultJsonObjectParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultJsonArrayParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultJsonArrayParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultDataObjectParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultDataObjectParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultEnumParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultEnumParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultGenEnumParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultGenEnumParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultUserTypeParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultUserTypeParameterized(io.vertx.core.Handler)"](function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), RefedInterface1._create), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param type {todo} 
+   @return {GenericRefedInterface}
+   */
+  this.methodWithClassTypeParameterizedReturn = function(type) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_genericsTCK["methodWithClassTypeParameterizedReturn(java.lang.Class)"](utils.javaTypeOf(type)), __args[0]._create);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param type {todo} 
+   @param handler {function} 
+   */
+  this.methodWithHandlerClassTypeParameterized = function(type, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'function' && typeof __args[1] === 'function') {
+      j_genericsTCK["methodWithHandlerClassTypeParameterized(java.lang.Class,io.vertx.core.Handler)"](utils.javaTypeOf(type), function(jVal) {
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, __args[0]._create));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param type {todo} 
+   @param handler {function} 
+   */
+  this.methodWithHandlerAsyncResultClassTypeParameterized = function(type, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'function' && typeof __args[1] === 'function') {
+      j_genericsTCK["methodWithHandlerAsyncResultClassTypeParameterized(java.lang.Class,io.vertx.core.Handler)"](utils.javaTypeOf(type), function(ar) {
+      if (ar.succeeded()) {
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), __args[0]._create), null);
+      } else {
+        handler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  // A reference to the underlying Java delegate
+  // NOTE! This is an internal API and must not be used in user code.
+  // If you rely on this property your code is likely to break if we change it / remove it without warning.
+  this._jdel = j_genericsTCK;
+};
+
+GenericsTCK._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.GenericsTCK");
+GenericsTCK._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(GenericsTCK.prototype, {});
+  GenericsTCK.apply(obj, arguments);
+  return obj;
+}
+// We export the Constructor function
+module.exports = GenericsTCK;

--- a/src/test/resources/testmodel-js/generics_tck.js
+++ b/src/test/resources/testmodel-js/generics_tck.js
@@ -714,6 +714,231 @@ var GenericsTCK = function(j_val) {
   /**
 
    @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamByteParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamByteParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamShortParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamShortParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamIntegerParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamIntegerParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamLongParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamLongParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamFloatParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamFloatParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamDoubleParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamDoubleParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamBooleanParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamBooleanParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamCharacterParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamCharacterParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamStringParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamStringParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamJsonObjectParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamJsonObjectParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamJsonArrayParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamJsonArrayParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamDataObjectParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamDataObjectParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamEnumParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamEnumParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, utils.enum_jtype(io.vertx.codegen.testmodel.TestEnum)));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamGenEnumParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamGenEnumParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, utils.enum_jtype(io.vertx.codegen.testmodel.TestGenEnum)));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamUserTypeParameterized = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_genericsTCK["methodWithFunctionParamUserTypeParameterized(java.util.function.Function)"](function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, RefedInterface1._jtype));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
    @param type {todo} 
    @return {GenericRefedInterface}
    */
@@ -754,6 +979,114 @@ var GenericsTCK = function(j_val) {
       } else {
         handler(null, ar.cause());
       }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param type {todo} 
+   @param handler {todo} 
+   */
+  this.methodWithFunctionParamClassTypeParameterized = function(type, handler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'function' && typeof __args[1] === 'function') {
+      j_genericsTCK["methodWithFunctionParamClassTypeParameterized(java.lang.Class,java.util.function.Function)"](utils.get_jclass(type), function(jVal) {
+      var jRet = handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, utils.get_jtype(type)));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param type {todo} 
+   @param u {Object} 
+   */
+  this.methodWithClassTypeParam = function(type, u) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'function' && typeof __args[1] !== 'function') {
+      j_genericsTCK["methodWithClassTypeParam(java.lang.Class,java.lang.Object)"](utils.get_jclass(type), utils.get_jtype(type).unwrap(u));
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param type {todo} 
+   @return {Object}
+   */
+  this.methodWithClassTypeReturn = function(type) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      return utils.get_jtype(type).wrap(j_genericsTCK["methodWithClassTypeReturn(java.lang.Class)"](utils.get_jclass(type)));
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param type {todo} 
+   @param f {function} 
+   */
+  this.methodWithClassTypeHandler = function(type, f) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'function' && typeof __args[1] === 'function') {
+      j_genericsTCK["methodWithClassTypeHandler(java.lang.Class,io.vertx.core.Handler)"](utils.get_jclass(type), function(jVal) {
+      f(utils.get_jtype(type).wrap(jVal));
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param type {todo} 
+   @param f {function} 
+   */
+  this.methodWithClassTypeHandlerAsyncResult = function(type, f) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'function' && typeof __args[1] === 'function') {
+      j_genericsTCK["methodWithClassTypeHandlerAsyncResult(java.lang.Class,io.vertx.core.Handler)"](utils.get_jclass(type), function(ar) {
+      if (ar.succeeded()) {
+        f(utils.get_jtype(type).wrap(ar.result()), null);
+      } else {
+        f(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param type {todo} 
+   @param f {todo} 
+   */
+  this.methodWithClassTypeFunctionParam = function(type, f) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'function' && typeof __args[1] === 'function') {
+      j_genericsTCK["methodWithClassTypeFunctionParam(java.lang.Class,java.util.function.Function)"](utils.get_jclass(type), function(jVal) {
+      var jRet = f(utils.get_jtype(type).wrap(jVal));
+      return jRet;
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param type {todo} 
+   @param f {todo} 
+   */
+  this.methodWithClassTypeFunctionReturn = function(type, f) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'function' && typeof __args[1] === 'function') {
+      j_genericsTCK["methodWithClassTypeFunctionReturn(java.lang.Class,java.util.function.Function)"](utils.get_jclass(type), function(jVal) {
+      var jRet = f(jVal);
+      return utils.get_jtype(type).unwrap(jRet);
     });
     } else throw new TypeError('function invoked with invalid arguments');
   };

--- a/src/test/resources/testmodel-js/interface_with_api_arg.js
+++ b/src/test/resources/testmodel-js/interface_with_api_arg.js
@@ -37,11 +37,13 @@ var InterfaceWithApiArg = function(j_val) {
 
    @public
    @param value {RefedInterface1} 
+   @return {GenericRefedInterface}
    */
   this.setValue = function(value) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'object' && __args[0]._jdel) {
       j_interfaceWithApiArg["setValue(io.vertx.codegen.testmodel.RefedInterface1)"](value._jdel);
+      return that;
     } else throw new TypeError('function invoked with invalid arguments');
   };
 

--- a/src/test/resources/testmodel-js/interface_with_api_arg.js
+++ b/src/test/resources/testmodel-js/interface_with_api_arg.js
@@ -14,75 +14,88 @@
  * under the License.
  */
 
-/** @module testmodel-js/refed_interface1 */
+/** @module testmodel-js/interface_with_api_arg */
 var utils = require('vertx-js/util/utils');
+var GenericRefedInterface = require('testmodel-js/generic_refed_interface');
+var RefedInterface1 = require('testmodel-js/refed_interface1');
 
 var io = Packages.io;
 var JsonObject = io.vertx.core.json.JsonObject;
-var JRefedInterface1 = io.vertx.codegen.testmodel.RefedInterface1;
+var JInterfaceWithApiArg = io.vertx.codegen.testmodel.InterfaceWithApiArg;
 
 /**
 
  @class
 */
-var RefedInterface1 = function(j_val) {
+var InterfaceWithApiArg = function(j_val) {
 
-  var j_refedInterface1 = j_val;
+  var j_interfaceWithApiArg = j_val;
   var that = this;
+  GenericRefedInterface.call(this, j_val, RefedInterface1._jtype);
 
   /**
 
    @public
-
-   @return {string}
+   @param value {RefedInterface1} 
    */
-  this.getString = function() {
+  this.setValue = function(value) {
     var __args = arguments;
-    if (__args.length === 0) {
-      return j_refedInterface1["getString()"]();
+    if (__args.length === 1 && typeof __args[0] === 'object' && __args[0]._jdel) {
+      j_interfaceWithApiArg["setValue(io.vertx.codegen.testmodel.RefedInterface1)"](value._jdel);
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
   /**
 
    @public
-   @param str {string} 
+
    @return {RefedInterface1}
    */
-  this.setString = function(str) {
+  this.getValue = function() {
     var __args = arguments;
-    if (__args.length === 1 && typeof __args[0] === 'string') {
-      j_refedInterface1["setString(java.lang.String)"](str);
-      return that;
+    if (__args.length === 0) {
+      return utils.convReturnVertxGen(RefedInterface1, j_interfaceWithApiArg["getValue()"]());
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   */
+  this.meth = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      j_interfaceWithApiArg["meth()"]();
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.
-  this._jdel = j_refedInterface1;
+  this._jdel = j_interfaceWithApiArg;
 };
 
-RefedInterface1._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.RefedInterface1");
-RefedInterface1._jtype = {
+InterfaceWithApiArg._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.InterfaceWithApiArg");
+InterfaceWithApiArg._jtype = {
   accept: function(obj) {
-    return RefedInterface1._jclass.isInstance(obj._jdel);
+    return InterfaceWithApiArg._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
     // A bit of jiggery pokery to create the object given a reference to the constructor function
-    var obj = Object.create(RefedInterface1.prototype, {});
-    RefedInterface1.apply(obj, arguments);
+    var obj = Object.create(InterfaceWithApiArg.prototype, {});
+    InterfaceWithApiArg.apply(obj, arguments);
     return obj;
   },
   unwrap: function(obj) {
     return obj._jdel;
   }
 };
-RefedInterface1._create = function(jdel) {
+InterfaceWithApiArg._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
-  var obj = Object.create(RefedInterface1.prototype, {});
-  RefedInterface1.apply(obj, arguments);
+  var obj = Object.create(InterfaceWithApiArg.prototype, {});
+  InterfaceWithApiArg.apply(obj, arguments);
   return obj;
 }
 // We export the Constructor function
-module.exports = RefedInterface1;
+module.exports = InterfaceWithApiArg;

--- a/src/test/resources/testmodel-js/interface_with_api_arg.js
+++ b/src/test/resources/testmodel-js/interface_with_api_arg.js
@@ -84,7 +84,6 @@ InterfaceWithApiArg._jtype = {
     return InterfaceWithApiArg._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(InterfaceWithApiArg.prototype, {});
     InterfaceWithApiArg.apply(obj, arguments);
     return obj;
@@ -94,10 +93,8 @@ InterfaceWithApiArg._jtype = {
   }
 };
 InterfaceWithApiArg._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(InterfaceWithApiArg.prototype, {});
   InterfaceWithApiArg.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = InterfaceWithApiArg;

--- a/src/test/resources/testmodel-js/interface_with_string_arg.js
+++ b/src/test/resources/testmodel-js/interface_with_string_arg.js
@@ -36,11 +36,13 @@ var InterfaceWithStringArg = function(j_val) {
 
    @public
    @param value {string} 
+   @return {GenericRefedInterface}
    */
   this.setValue = function(value) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'string') {
       j_interfaceWithStringArg["setValue(java.lang.String)"](value);
+      return that;
     } else throw new TypeError('function invoked with invalid arguments');
   };
 

--- a/src/test/resources/testmodel-js/interface_with_string_arg.js
+++ b/src/test/resources/testmodel-js/interface_with_string_arg.js
@@ -83,7 +83,6 @@ InterfaceWithStringArg._jtype = {
     return InterfaceWithStringArg._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(InterfaceWithStringArg.prototype, {});
     InterfaceWithStringArg.apply(obj, arguments);
     return obj;
@@ -93,10 +92,8 @@ InterfaceWithStringArg._jtype = {
   }
 };
 InterfaceWithStringArg._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(InterfaceWithStringArg.prototype, {});
   InterfaceWithStringArg.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = InterfaceWithStringArg;

--- a/src/test/resources/testmodel-js/interface_with_string_arg.js
+++ b/src/test/resources/testmodel-js/interface_with_string_arg.js
@@ -14,21 +14,35 @@
  * under the License.
  */
 
-/** @module testmodel-js/refed_interface1 */
+/** @module testmodel-js/interface_with_string_arg */
 var utils = require('vertx-js/util/utils');
+var GenericRefedInterface = require('testmodel-js/generic_refed_interface');
 
 var io = Packages.io;
 var JsonObject = io.vertx.core.json.JsonObject;
-var JRefedInterface1 = io.vertx.codegen.testmodel.RefedInterface1;
+var JInterfaceWithStringArg = io.vertx.codegen.testmodel.InterfaceWithStringArg;
 
 /**
 
  @class
 */
-var RefedInterface1 = function(j_val) {
+var InterfaceWithStringArg = function(j_val) {
 
-  var j_refedInterface1 = j_val;
+  var j_interfaceWithStringArg = j_val;
   var that = this;
+  GenericRefedInterface.call(this, j_val, undefined);
+
+  /**
+
+   @public
+   @param value {string} 
+   */
+  this.setValue = function(value) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'string') {
+      j_interfaceWithStringArg["setValue(java.lang.String)"](value);
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
 
   /**
 
@@ -36,53 +50,51 @@ var RefedInterface1 = function(j_val) {
 
    @return {string}
    */
-  this.getString = function() {
+  this.getValue = function() {
     var __args = arguments;
     if (__args.length === 0) {
-      return j_refedInterface1["getString()"]();
+      return j_interfaceWithStringArg["getValue()"]();
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
   /**
 
    @public
-   @param str {string} 
-   @return {RefedInterface1}
+
    */
-  this.setString = function(str) {
+  this.meth = function() {
     var __args = arguments;
-    if (__args.length === 1 && typeof __args[0] === 'string') {
-      j_refedInterface1["setString(java.lang.String)"](str);
-      return that;
+    if (__args.length === 0) {
+      j_interfaceWithStringArg["meth()"]();
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.
-  this._jdel = j_refedInterface1;
+  this._jdel = j_interfaceWithStringArg;
 };
 
-RefedInterface1._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.RefedInterface1");
-RefedInterface1._jtype = {
+InterfaceWithStringArg._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.InterfaceWithStringArg");
+InterfaceWithStringArg._jtype = {
   accept: function(obj) {
-    return RefedInterface1._jclass.isInstance(obj._jdel);
+    return InterfaceWithStringArg._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
     // A bit of jiggery pokery to create the object given a reference to the constructor function
-    var obj = Object.create(RefedInterface1.prototype, {});
-    RefedInterface1.apply(obj, arguments);
+    var obj = Object.create(InterfaceWithStringArg.prototype, {});
+    InterfaceWithStringArg.apply(obj, arguments);
     return obj;
   },
   unwrap: function(obj) {
     return obj._jdel;
   }
 };
-RefedInterface1._create = function(jdel) {
+InterfaceWithStringArg._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
-  var obj = Object.create(RefedInterface1.prototype, {});
-  RefedInterface1.apply(obj, arguments);
+  var obj = Object.create(InterfaceWithStringArg.prototype, {});
+  InterfaceWithStringArg.apply(obj, arguments);
   return obj;
 }
 // We export the Constructor function
-module.exports = RefedInterface1;
+module.exports = InterfaceWithStringArg;

--- a/src/test/resources/testmodel-js/interface_with_variable_arg.js
+++ b/src/test/resources/testmodel-js/interface_with_variable_arg.js
@@ -38,11 +38,13 @@ var InterfaceWithVariableArg = function(j_val, j_arg_0, j_arg_1) {
 
    @public
    @param value {Object} 
+   @return {GenericRefedInterface}
    */
   this.setValue = function(value) {
     var __args = arguments;
     if (__args.length === 1 && j_U.accept(__args[0])) {
       j_interfaceWithVariableArg["setValue(java.lang.Object)"](j_U.unwrap(value));
+      return that;
     } else throw new TypeError('function invoked with invalid arguments');
   };
 

--- a/src/test/resources/testmodel-js/interface_with_variable_arg.js
+++ b/src/test/resources/testmodel-js/interface_with_variable_arg.js
@@ -98,7 +98,6 @@ InterfaceWithVariableArg._jtype = {
     return InterfaceWithVariableArg._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(InterfaceWithVariableArg.prototype, {});
     InterfaceWithVariableArg.apply(obj, arguments);
     return obj;
@@ -108,10 +107,8 @@ InterfaceWithVariableArg._jtype = {
   }
 };
 InterfaceWithVariableArg._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(InterfaceWithVariableArg.prototype, {});
   InterfaceWithVariableArg.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = InterfaceWithVariableArg;

--- a/src/test/resources/testmodel-js/interface_with_variable_arg.js
+++ b/src/test/resources/testmodel-js/interface_with_variable_arg.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** @module testmodel-js/interface_with_variable_arg */
+var utils = require('vertx-js/util/utils');
+var GenericRefedInterface = require('testmodel-js/generic_refed_interface');
+
+var io = Packages.io;
+var JsonObject = io.vertx.core.json.JsonObject;
+var JInterfaceWithVariableArg = io.vertx.codegen.testmodel.InterfaceWithVariableArg;
+
+/**
+
+ @class
+*/
+var InterfaceWithVariableArg = function(j_val, j_arg_0, j_arg_1) {
+
+  var j_interfaceWithVariableArg = j_val;
+  var that = this;
+  var j_T = typeof j_arg_0 !== 'undefined' ? j_arg_0 : utils.unknown_jtype;
+  var j_U = typeof j_arg_1 !== 'undefined' ? j_arg_1 : utils.unknown_jtype;
+  GenericRefedInterface.call(this, j_val, j_U);
+
+  /**
+
+   @public
+   @param value {Object} 
+   */
+  this.setValue = function(value) {
+    var __args = arguments;
+    if (__args.length === 1 && j_U.accept(__args[0])) {
+      j_interfaceWithVariableArg["setValue(java.lang.Object)"](j_U.unwrap(value));
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {Object}
+   */
+  this.getValue = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return j_U.wrap(j_interfaceWithVariableArg["getValue()"]());
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param value {Object} 
+   */
+  this.setOtherValue = function(value) {
+    var __args = arguments;
+    if (__args.length === 1 && j_T.accept(__args[0])) {
+      j_interfaceWithVariableArg["setOtherValue(java.lang.Object)"](j_T.unwrap(value));
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+
+   @return {Object}
+   */
+  this.getOtherValue = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return j_T.wrap(j_interfaceWithVariableArg["getOtherValue()"]());
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  // A reference to the underlying Java delegate
+  // NOTE! This is an internal API and must not be used in user code.
+  // If you rely on this property your code is likely to break if we change it / remove it without warning.
+  this._jdel = j_interfaceWithVariableArg;
+};
+
+InterfaceWithVariableArg._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.InterfaceWithVariableArg");
+InterfaceWithVariableArg._jtype = {
+  accept: function(obj) {
+    return InterfaceWithVariableArg._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(InterfaceWithVariableArg.prototype, {});
+    InterfaceWithVariableArg.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
+InterfaceWithVariableArg._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(InterfaceWithVariableArg.prototype, {});
+  InterfaceWithVariableArg.apply(obj, arguments);
+  return obj;
+}
+// We export the Constructor function
+module.exports = InterfaceWithVariableArg;

--- a/src/test/resources/testmodel-js/nullable_tck.js
+++ b/src/test/resources/testmodel-js/nullable_tck.js
@@ -6617,7 +6617,6 @@ NullableTCK._jtype = {
     return NullableTCK._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(NullableTCK.prototype, {});
     NullableTCK.apply(obj, arguments);
     return obj;
@@ -6627,10 +6626,8 @@ NullableTCK._jtype = {
   }
 };
 NullableTCK._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(NullableTCK.prototype, {});
   NullableTCK.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = NullableTCK;

--- a/src/test/resources/testmodel-js/nullable_tck.js
+++ b/src/test/resources/testmodel-js/nullable_tck.js
@@ -871,7 +871,7 @@ var NullableTCK = function(j_val) {
     var __args = arguments;
     if (__args.length === 2 && typeof __args[0] ==='boolean' && typeof __args[1] === 'function') {
       j_nullableTCK["methodWithNullableApiHandler(boolean,io.vertx.core.Handler)"](notNull, function(jVal) {
-      handler(utils.convReturnVertxGen(jVal, RefedInterface1));
+      handler(utils.convReturnVertxGen(RefedInterface1, jVal));
     });
     } else throw new TypeError('function invoked with invalid arguments');
   };
@@ -887,7 +887,7 @@ var NullableTCK = function(j_val) {
     if (__args.length === 2 && typeof __args[0] ==='boolean' && typeof __args[1] === 'function') {
       j_nullableTCK["methodWithNullableApiHandlerAsyncResult(boolean,io.vertx.core.Handler)"](notNull, function(ar) {
       if (ar.succeeded()) {
-        handler(utils.convReturnVertxGen(ar.result(), RefedInterface1), null);
+        handler(utils.convReturnVertxGen(RefedInterface1, ar.result()), null);
       } else {
         handler(null, ar.cause());
       }
@@ -904,7 +904,7 @@ var NullableTCK = function(j_val) {
   this.methodWithNullableApiReturn = function(notNull) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] ==='boolean') {
-      return utils.convReturnVertxGen(j_nullableTCK["methodWithNullableApiReturn(boolean)"](notNull), RefedInterface1);
+      return utils.convReturnVertxGen(RefedInterface1, j_nullableTCK["methodWithNullableApiReturn(boolean)"](notNull));
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -6611,5 +6611,12 @@ var NullableTCK = function(j_val) {
   this._jdel = j_nullableTCK;
 };
 
+NullableTCK._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.NullableTCK");
+NullableTCK._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(NullableTCK.prototype, {});
+  NullableTCK.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = NullableTCK;

--- a/src/test/resources/testmodel-js/nullable_tck.js
+++ b/src/test/resources/testmodel-js/nullable_tck.js
@@ -6612,6 +6612,20 @@ var NullableTCK = function(j_val) {
 };
 
 NullableTCK._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.NullableTCK");
+NullableTCK._jtype = {
+  accept: function(obj) {
+    return NullableTCK._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(NullableTCK.prototype, {});
+    NullableTCK.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 NullableTCK._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(NullableTCK.prototype, {});

--- a/src/test/resources/testmodel-js/refed_interface1.js
+++ b/src/test/resources/testmodel-js/refed_interface1.js
@@ -69,7 +69,6 @@ RefedInterface1._jtype = {
     return RefedInterface1._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(RefedInterface1.prototype, {});
     RefedInterface1.apply(obj, arguments);
     return obj;
@@ -79,10 +78,8 @@ RefedInterface1._jtype = {
   }
 };
 RefedInterface1._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(RefedInterface1.prototype, {});
   RefedInterface1.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = RefedInterface1;

--- a/src/test/resources/testmodel-js/refed_interface1.js
+++ b/src/test/resources/testmodel-js/refed_interface1.js
@@ -63,5 +63,12 @@ var RefedInterface1 = function(j_val) {
   this._jdel = j_refedInterface1;
 };
 
+RefedInterface1._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.RefedInterface1");
+RefedInterface1._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(RefedInterface1.prototype, {});
+  RefedInterface1.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = RefedInterface1;

--- a/src/test/resources/testmodel-js/refed_interface2.js
+++ b/src/test/resources/testmodel-js/refed_interface2.js
@@ -63,5 +63,12 @@ var RefedInterface2 = function(j_val) {
   this._jdel = j_refedInterface2;
 };
 
+RefedInterface2._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.RefedInterface2");
+RefedInterface2._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(RefedInterface2.prototype, {});
+  RefedInterface2.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = RefedInterface2;

--- a/src/test/resources/testmodel-js/refed_interface2.js
+++ b/src/test/resources/testmodel-js/refed_interface2.js
@@ -69,7 +69,6 @@ RefedInterface2._jtype = {
     return RefedInterface2._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(RefedInterface2.prototype, {});
     RefedInterface2.apply(obj, arguments);
     return obj;
@@ -79,10 +78,8 @@ RefedInterface2._jtype = {
   }
 };
 RefedInterface2._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(RefedInterface2.prototype, {});
   RefedInterface2.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = RefedInterface2;

--- a/src/test/resources/testmodel-js/refed_interface2.js
+++ b/src/test/resources/testmodel-js/refed_interface2.js
@@ -64,6 +64,20 @@ var RefedInterface2 = function(j_val) {
 };
 
 RefedInterface2._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.RefedInterface2");
+RefedInterface2._jtype = {
+  accept: function(obj) {
+    return RefedInterface2._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(RefedInterface2.prototype, {});
+    RefedInterface2.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 RefedInterface2._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(RefedInterface2.prototype, {});

--- a/src/test/resources/testmodel-js/super_interface1.js
+++ b/src/test/resources/testmodel-js/super_interface1.js
@@ -70,6 +70,20 @@ var SuperInterface1 = function(j_val) {
 };
 
 SuperInterface1._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.SuperInterface1");
+SuperInterface1._jtype = {
+  accept: function(obj) {
+    return SuperInterface1._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(SuperInterface1.prototype, {});
+    SuperInterface1.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 SuperInterface1._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(SuperInterface1.prototype, {});

--- a/src/test/resources/testmodel-js/super_interface1.js
+++ b/src/test/resources/testmodel-js/super_interface1.js
@@ -75,7 +75,6 @@ SuperInterface1._jtype = {
     return SuperInterface1._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(SuperInterface1.prototype, {});
     SuperInterface1.apply(obj, arguments);
     return obj;
@@ -85,10 +84,8 @@ SuperInterface1._jtype = {
   }
 };
 SuperInterface1._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(SuperInterface1.prototype, {});
   SuperInterface1.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = SuperInterface1;

--- a/src/test/resources/testmodel-js/super_interface1.js
+++ b/src/test/resources/testmodel-js/super_interface1.js
@@ -69,5 +69,12 @@ var SuperInterface1 = function(j_val) {
   this._jdel = j_superInterface1;
 };
 
+SuperInterface1._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.SuperInterface1");
+SuperInterface1._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(SuperInterface1.prototype, {});
+  SuperInterface1.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = SuperInterface1;

--- a/src/test/resources/testmodel-js/super_interface2.js
+++ b/src/test/resources/testmodel-js/super_interface2.js
@@ -62,7 +62,6 @@ SuperInterface2._jtype = {
     return SuperInterface2._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(SuperInterface2.prototype, {});
     SuperInterface2.apply(obj, arguments);
     return obj;
@@ -72,10 +71,8 @@ SuperInterface2._jtype = {
   }
 };
 SuperInterface2._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(SuperInterface2.prototype, {});
   SuperInterface2.apply(obj, arguments);
   return obj;
 }
-// We export the Constructor function
 module.exports = SuperInterface2;

--- a/src/test/resources/testmodel-js/super_interface2.js
+++ b/src/test/resources/testmodel-js/super_interface2.js
@@ -57,6 +57,20 @@ var SuperInterface2 = function(j_val) {
 };
 
 SuperInterface2._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.SuperInterface2");
+SuperInterface2._jtype = {
+  accept: function(obj) {
+    return SuperInterface2._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(SuperInterface2.prototype, {});
+    SuperInterface2.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 SuperInterface2._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(SuperInterface2.prototype, {});

--- a/src/test/resources/testmodel-js/super_interface2.js
+++ b/src/test/resources/testmodel-js/super_interface2.js
@@ -56,5 +56,12 @@ var SuperInterface2 = function(j_val) {
   this._jdel = j_superInterface2;
 };
 
+SuperInterface2._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.SuperInterface2");
+SuperInterface2._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(SuperInterface2.prototype, {});
+  SuperInterface2.apply(obj, arguments);
+  return obj;
+}
 // We export the Constructor function
 module.exports = SuperInterface2;

--- a/src/test/resources/testmodel-js/test_interface.js
+++ b/src/test/resources/testmodel-js/test_interface.js
@@ -497,7 +497,7 @@ var TestInterface = function(j_val) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_testInterface["methodWithHandlerUserTypes(io.vertx.core.Handler)"](function(jVal) {
-      handler(utils.convReturnVertxGen(jVal, RefedInterface1));
+      handler(utils.convReturnVertxGen(RefedInterface1, jVal));
     });
     } else throw new TypeError('function invoked with invalid arguments');
   };
@@ -512,7 +512,7 @@ var TestInterface = function(j_val) {
     if (__args.length === 1 && typeof __args[0] === 'function') {
       j_testInterface["methodWithHandlerAsyncResultUserTypes(io.vertx.core.Handler)"](function(ar) {
       if (ar.succeeded()) {
-        handler(utils.convReturnVertxGen(ar.result(), RefedInterface1), null);
+        handler(utils.convReturnVertxGen(RefedInterface1, ar.result()), null);
       } else {
         handler(null, ar.cause());
       }
@@ -625,7 +625,7 @@ var TestInterface = function(j_val) {
     var __args = arguments;
     if (__args.length === 2 && typeof __args[0] !== 'function' && typeof __args[1] === 'function') {
       j_testInterface["methodWithHandlerGenericUserType(java.lang.Object,io.vertx.core.Handler)"](utils.convParamTypeUnknown(value), function(jVal) {
-      handler(utils.convReturnVertxGen(jVal, GenericRefedInterface));
+      handler(utils.convReturnVertxGen(GenericRefedInterface, jVal, undefined));
     });
     } else throw new TypeError('function invoked with invalid arguments');
   };
@@ -641,7 +641,7 @@ var TestInterface = function(j_val) {
     if (__args.length === 2 && typeof __args[0] !== 'function' && typeof __args[1] === 'function') {
       j_testInterface["methodWithHandlerAsyncResultGenericUserType(java.lang.Object,io.vertx.core.Handler)"](utils.convParamTypeUnknown(value), function(ar) {
       if (ar.succeeded()) {
-        handler(utils.convReturnVertxGen(ar.result(), GenericRefedInterface), null);
+        handler(utils.convReturnVertxGen(GenericRefedInterface, ar.result(), undefined), null);
       } else {
         handler(null, ar.cause());
       }
@@ -775,7 +775,7 @@ var TestInterface = function(j_val) {
   this.methodWithVertxGenReturn = function() {
     var __args = arguments;
     if (__args.length === 0) {
-      return utils.convReturnVertxGen(j_testInterface["methodWithVertxGenReturn()"](), RefedInterface1);
+      return utils.convReturnVertxGen(RefedInterface1, j_testInterface["methodWithVertxGenReturn()"]());
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -788,7 +788,7 @@ var TestInterface = function(j_val) {
   this.methodWithVertxGenNullReturn = function() {
     var __args = arguments;
     if (__args.length === 0) {
-      return utils.convReturnVertxGen(j_testInterface["methodWithVertxGenNullReturn()"](), RefedInterface1);
+      return utils.convReturnVertxGen(RefedInterface1, j_testInterface["methodWithVertxGenNullReturn()"]());
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -801,7 +801,7 @@ var TestInterface = function(j_val) {
   this.methodWithAbstractVertxGenReturn = function() {
     var __args = arguments;
     if (__args.length === 0) {
-      return utils.convReturnVertxGen(j_testInterface["methodWithAbstractVertxGenReturn()"](), RefedInterface2);
+      return utils.convReturnVertxGen(RefedInterface2, j_testInterface["methodWithAbstractVertxGenReturn()"]());
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -828,6 +828,19 @@ var TestInterface = function(j_val) {
     var __args = arguments;
     if (__args.length === 0) {
       return utils.convReturnDataObject(j_testInterface["methodWithDataObjectNullReturn()"]());
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param value {Object} 
+   @return {GenericRefedInterface}
+   */
+  this.methodWithGenericUserTypeReturn = function(value) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] !== 'function') {
+      return utils.convReturnVertxGen(GenericRefedInterface, j_testInterface["methodWithGenericUserTypeReturn(java.lang.Object)"](utils.convParamTypeUnknown(value)), undefined);
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -943,7 +956,7 @@ var TestInterface = function(j_val) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'string') {
       if (that.cachedmethodWithCachedReturn == null) {
-        that.cachedmethodWithCachedReturn = utils.convReturnVertxGen(j_testInterface["methodWithCachedReturn(java.lang.String)"](foo), RefedInterface1);
+        that.cachedmethodWithCachedReturn = utils.convReturnVertxGen(RefedInterface1, j_testInterface["methodWithCachedReturn(java.lang.String)"](foo));
       }
       return that.cachedmethodWithCachedReturn;
     } else throw new TypeError('function invoked with invalid arguments');
@@ -1313,6 +1326,13 @@ var TestInterface = function(j_val) {
   this._jdel = j_testInterface;
 };
 
+TestInterface._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.TestInterface");
+TestInterface._create = function(jdel) {
+  // A bit of jiggery pokery to create the object given a reference to the constructor function
+  var obj = Object.create(TestInterface.prototype, {});
+  TestInterface.apply(obj, arguments);
+  return obj;
+}
 /**
 
  @memberof module:testmodel-js/test_interface
@@ -1322,7 +1342,7 @@ var TestInterface = function(j_val) {
 TestInterface.staticFactoryMethod = function(foo) {
   var __args = arguments;
   if (__args.length === 1 && typeof __args[0] === 'string') {
-    return utils.convReturnVertxGen(JTestInterface["staticFactoryMethod(java.lang.String)"](foo), RefedInterface1);
+    return utils.convReturnVertxGen(RefedInterface1, JTestInterface["staticFactoryMethod(java.lang.String)"](foo));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 

--- a/src/test/resources/testmodel-js/test_interface.js
+++ b/src/test/resources/testmodel-js/test_interface.js
@@ -1327,6 +1327,20 @@ var TestInterface = function(j_val) {
 };
 
 TestInterface._jclass = utils.getJavaClass("io.vertx.codegen.testmodel.TestInterface");
+TestInterface._jtype = {
+  accept: function(obj) {
+    return TestInterface._jclass.isInstance(obj._jdel);
+  },
+  wrap: function(jdel) {
+    // A bit of jiggery pokery to create the object given a reference to the constructor function
+    var obj = Object.create(TestInterface.prototype, {});
+    TestInterface.apply(obj, arguments);
+    return obj;
+  },
+  unwrap: function(obj) {
+    return obj._jdel;
+  }
+};
 TestInterface._create = function(jdel) {
   // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(TestInterface.prototype, {});

--- a/src/test/resources/testmodel-js/test_interface.js
+++ b/src/test/resources/testmodel-js/test_interface.js
@@ -1332,7 +1332,6 @@ TestInterface._jtype = {
     return TestInterface._jclass.isInstance(obj._jdel);
   },
   wrap: function(jdel) {
-    // A bit of jiggery pokery to create the object given a reference to the constructor function
     var obj = Object.create(TestInterface.prototype, {});
     TestInterface.apply(obj, arguments);
     return obj;
@@ -1342,7 +1341,6 @@ TestInterface._jtype = {
   }
 };
 TestInterface._create = function(jdel) {
-  // A bit of jiggery pokery to create the object given a reference to the constructor function
   var obj = Object.create(TestInterface.prototype, {});
   TestInterface.apply(obj, arguments);
   return obj;
@@ -1360,5 +1358,4 @@ TestInterface.staticFactoryMethod = function(foo) {
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
-// We export the Constructor function
 module.exports = TestInterface;


### PR DESCRIPTION
Provides support for `GenericApi<String>` as argument and return types and support for `<U> GenericApi<U> m(Class<U>)` or even `U m(Class<U>)`